### PR TITLE
Add support for OpenSSL 1.1

### DIFF
--- a/src/h235/h235crypto.cxx
+++ b/src/h235/h235crypto.cxx
@@ -44,8 +44,11 @@
 #include "h235/h235crypto.h"
 #include "h235/h235caps.h"
 #include "h235/h235support.h"
+extern "C" {
+#include <openssl/opensslv.h>
+#include <openssl/evp.h>
 #include <openssl/rand.h>
-
+}
 #include "rtp.h"
 
 #ifdef H323_H235_AES256
@@ -61,70 +64,90 @@
 const unsigned int IV_SEQUENCE_LEN = 6;
 
 
-// ciphertext stealing code based on a OpenSSL patch by An-Cheng Huang
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
+
+inline const unsigned char *EVP_CIPHER_CTX_iv(const EVP_CIPHER_CTX *ctx)
+{
+    return ctx->iv;
+}
+
+#endif // (OPENSSL_VERSION_NUMBER < 0x10100000L)
+
+// ciphertext stealing (CTS) code based on a OpenSSL patch by An-Cheng Huang
 // Note: This ciphertext stealing implementation doesn't seem to always produce
 // compatible results, avoid when encrypting:
+H235CryptoHelper::H235CryptoHelper()
+{
+    memset(buf, 0, sizeof(buf));
+    memset(final_buf, 0, sizeof(final_buf));
+    Reset();
+}
 
-int EVP_EncryptUpdate_cts(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
+inline void H235CryptoHelper::Reset()
+{
+    buf_len = 0;
+    final_used = 0;
+}
+
+int H235CryptoHelper::EncryptUpdateCTS(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
                       const unsigned char *in, int inl)
 {
-    int bl = ctx->cipher->block_size;
-    OPENSSL_assert(bl <= (int)sizeof(ctx->buf));
+    const int bl = EVP_CIPHER_CTX_block_size(ctx);
+    OPENSSL_assert(bl <= (int)sizeof(buf));
     *outl = 0;
 
-    if ((ctx->buf_len + inl) <= bl) {
+    if ((buf_len + inl) <= bl) {
         /* new plaintext is no more than 1 block */
         /* copy the in data into the buffer and return */
-        memcpy(&(ctx->buf[ctx->buf_len]), in, inl);
-        ctx->buf_len += inl;
-        *outl = 0;
+        memcpy(&(buf[buf_len]), in, inl);
+        buf_len += inl;
         return 1;
     }
 
     /* more than 1 block of new plaintext available */
     /* encrypt the previous plaintext, if any */
-    if (ctx->final_used) {
-        if (!(ctx->cipher->do_cipher(ctx, out, ctx->final, bl))) {
+    if (final_used) {
+        if (!(EVP_Cipher(ctx, out, final_buf, bl))) {
           return 0;
         }
         out += bl;
         *outl += bl;
-        ctx->final_used = 0;
+        final_used = 0;
     }
 
-    /* we already know ctx->buf_len + inl must be > bl */
-    memcpy(&(ctx->buf[ctx->buf_len]), in, (bl - ctx->buf_len));
-    in += (bl - ctx->buf_len);
-    inl -= (bl - ctx->buf_len);
-    ctx->buf_len = bl;
+    /* we already know buf_len + inl must be > bl */
+    memcpy(&(buf[buf_len]), in, (bl - buf_len));
+    in += (bl - buf_len);
+    inl -= (bl - buf_len);
+    buf_len = bl;
 
     if (inl <= bl) {
-        memcpy(ctx->final, ctx->buf, bl);
-        ctx->final_used = 1;
-        memcpy(ctx->buf, in, inl);
-        ctx->buf_len = inl;
+        memcpy(final_buf, buf, bl);
+        final_used = 1;
+        memcpy(buf, in, inl);
+        buf_len = inl;
         return 1;
     } else {
-        if (!(ctx->cipher->do_cipher(ctx, out, ctx->buf, bl))) {
+        if (!(EVP_Cipher(ctx, out, buf, bl))) {
             return 0;
         }
         out += bl;
         *outl += bl;
-        ctx->buf_len = 0;
+        buf_len = 0;
 
-        int leftover = inl & ctx->block_mask;
+        int leftover = inl & (bl - 1);
         if (leftover) {
             inl -= (bl + leftover);
-            memcpy(ctx->buf, &(in[(inl + bl)]), leftover);
-            ctx->buf_len = leftover;
+            memcpy(buf, &(in[(inl + bl)]), leftover);
+            buf_len = leftover;
         } else {
             inl -= (2 * bl);
-             memcpy(ctx->buf, &(in[(inl + bl)]), bl);
-             ctx->buf_len = bl;
+            memcpy(buf, &(in[(inl + bl)]), bl);
+            buf_len = bl;
         }
-        memcpy(ctx->final, &(in[inl]), bl);
-        ctx->final_used = 1;
-        if (!(ctx->cipher->do_cipher(ctx, out, in, inl))) {
+        memcpy(final_buf, &(in[inl]), bl);
+        final_used = 1;
+        if (!(EVP_Cipher(ctx, out, in, inl))) {
             return 0;
         }
         out += inl;
@@ -134,40 +157,36 @@ int EVP_EncryptUpdate_cts(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
     return 1;
 }
 
-#if PTLIB_VER >= 2130
-int EVP_EncryptFinal_ctsA(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
-#else
-int EVP_EncryptFinal_cts(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
-#endif
+int H235CryptoHelper::EncryptFinalCTS(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
 {
     unsigned char tmp[EVP_MAX_BLOCK_LENGTH];
-    int bl = ctx->cipher->block_size;
+    int bl = EVP_CIPHER_CTX_block_size(ctx);
     int leftover = 0;
     *outl = 0;
 
-    if (!ctx->final_used) {
+    if (!final_used) {
         PTRACE(1, "H235\tCTS Error: expecting previous ciphertext");
         return 0;
     }
-    if (ctx->buf_len == 0) {
+    if (buf_len == 0) {
         PTRACE(1, "H235\tCTS Error: expecting previous plaintext");
         return 0;
     }
 
     /* handle leftover bytes */
-    leftover = ctx->buf_len;
+    leftover = buf_len;
 
     switch (EVP_CIPHER_CTX_mode(ctx)) {
         case EVP_CIPH_ECB_MODE: {
             /* encrypt => C_{n} plus C' */
-            if (!(ctx->cipher->do_cipher(ctx, tmp, ctx->final, bl))) {
+            if (!(EVP_Cipher(ctx, tmp, final_buf, bl))) {
                  return 0;
             }
 
             /* P_n plus C' */
-            memcpy(&(ctx->buf[leftover]), &(tmp[leftover]), (bl - leftover));
+            memcpy(&(buf[leftover]), &(tmp[leftover]), (bl - leftover));
             /* encrypt => C_{n-1} */
-            if (!(ctx->cipher->do_cipher(ctx, out, ctx->buf, bl))) {
+            if (!(EVP_Cipher(ctx, out, buf, bl))) {
                 return 0;
             }
 
@@ -177,18 +196,18 @@ int EVP_EncryptFinal_cts(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
         }
         case EVP_CIPH_CBC_MODE: {
             /* encrypt => C_{n} plus C' */
-            if (!(ctx->cipher->do_cipher(ctx, tmp, ctx->final, bl))) {
+            if (!(EVP_Cipher(ctx, tmp, final_buf, bl))) {
                 return 0;
             }
 
             /* P_n plus 0s */
-            memset(&(ctx->buf[leftover]), 0, (bl - leftover));
+            memset(&(buf[leftover]), 0, (bl - leftover));
 
             /* note that in cbc encryption, plaintext will be xor'ed with the previous
              * ciphertext, which is what we want.
              */
             /* encrypt => C_{n-1} */
-            if (!(ctx->cipher->do_cipher(ctx, out, ctx->buf, bl))) {
+            if (!(EVP_Cipher(ctx, out, buf, bl))) {
                 return 0;
             }
 
@@ -196,48 +215,49 @@ int EVP_EncryptFinal_cts(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
             *outl += (bl + leftover);
             return 1;
         }
-        default:
+        default: {
             PTRACE(1, "H235\tCTS Error: unsupported mode");
             return 0;
+        }
     }
 }
 
-int EVP_DecryptUpdate_cts(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
+inline int H235CryptoHelper::DecryptUpdateCTS(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
                       const unsigned char *in, int inl)
 {
-    return EVP_EncryptUpdate_cts(ctx, out, outl, in, inl);
+    return EncryptUpdateCTS(ctx, out, outl, in, inl);
 }
 
-int EVP_DecryptFinal_cts(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
+int H235CryptoHelper::DecryptFinalCTS(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
 {
     unsigned char tmp[EVP_MAX_BLOCK_LENGTH];
-    int bl = ctx->cipher->block_size;
+    const int bl = EVP_CIPHER_CTX_block_size(ctx);
     int leftover = 0;
     *outl = 0;
 
-    if (!ctx->final_used) {
+    if (!final_used) {
         PTRACE(1, "H235\tCTS Error: expecting previous ciphertext");
         return 0;
     }
-    if (ctx->buf_len == 0) {
+    if (buf_len == 0) {
         PTRACE(1, "H235\tCTS Error: expecting previous ciphertext");
         return 0;
     }
 
     /* handle leftover bytes */
-    leftover = ctx->buf_len;
+    leftover = buf_len;
 
     switch (EVP_CIPHER_CTX_mode(ctx)) {
         case EVP_CIPH_ECB_MODE: {
             /* decrypt => P_n plus C' */
-            if (!(ctx->cipher->do_cipher(ctx, tmp, ctx->final, bl))) {
+            if (!(EVP_Cipher(ctx, tmp, final_buf, bl))) {
                 return 0;
             }
 
             /* C_n plus C' */
-            memcpy(&(ctx->buf[leftover]), &(tmp[leftover]), (bl - leftover));
+            memcpy(&(buf[leftover]), &(tmp[leftover]), (bl - leftover));
             /* decrypt => P_{n-1} */
-            if (!(ctx->cipher->do_cipher(ctx, out, ctx->buf, bl))) {
+            if (!(EVP_Cipher(ctx, out, buf, bl))) {
                 return 0;
             }
 
@@ -249,14 +269,14 @@ int EVP_DecryptFinal_cts(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
             int i = 0;
             unsigned char C_n_minus_2[EVP_MAX_BLOCK_LENGTH];
 
-            memcpy(C_n_minus_2, ctx->iv, bl);
+            memcpy(C_n_minus_2, EVP_CIPHER_CTX_iv(ctx), bl);
 
-            /* C_n plus 0s in ctx->buf */
-            memset(&(ctx->buf[leftover]), 0, (bl - leftover));
+            /* C_n plus 0s in buf */
+            memset(&(buf[leftover]), 0, (bl - leftover));
 
-            /* ctx->final is C_{n-1} */
+            /* final_buf is C_{n-1} */
             /* decrypt => (P_n plus C')'' */
-            if (!(ctx->cipher->do_cipher(ctx, tmp, ctx->final, bl))) {
+            if (!(EVP_Cipher(ctx, tmp, final_buf, bl))) {
                 return 0;
             }
             /* XOR'ed with C_{n-2} => (P_n plus C')' */
@@ -265,18 +285,18 @@ int EVP_DecryptFinal_cts(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
             }
             /* XOR'ed with (C_n plus 0s) => P_n plus C' */
             for (i = 0; i < bl; i++) {
-                tmp[i] = tmp[i] ^ ctx->buf[i];
+                tmp[i] = tmp[i] ^ buf[i];
             }
 
-            /* C_n plus C' in ctx->buf */
-            memcpy(&(ctx->buf[leftover]), &(tmp[leftover]), (bl - leftover));
+            /* C_n plus C' in buf */
+            memcpy(&(buf[leftover]), &(tmp[leftover]), (bl - leftover));
             /* decrypt => P_{n-1}'' */
-            if (!(ctx->cipher->do_cipher(ctx, out, ctx->buf, bl))) {
+            if (!(EVP_Cipher(ctx, out, buf, bl))) {
                 return 0;
             }
             /* XOR'ed with C_{n-1} => P_{n-1}' */
             for (i = 0; i < bl; i++) {
-                out[i] = out[i] ^ ctx->final[i];
+                out[i] = out[i] ^ final_buf[i];
             }
             /* XOR'ed with C_{n-2} => P_{n-1} */
             for (i = 0; i < bl; i++) {
@@ -287,64 +307,69 @@ int EVP_DecryptFinal_cts(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
             *outl += (bl + leftover);
             return 1;
         }
-        default:
+        default: {
             PTRACE(1, "H235\tCTS Error: unsupported mode");
             return 0;
+        }
     }
 }
 
-int EVP_DecryptFinal_relaxed(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
+int H235CryptoHelper::DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
+                      const unsigned char *in, int inl)
 {
-    unsigned int b = 0;
+    return EncryptUpdateCTS(ctx, out, outl, in, inl);
+}
+
+int H235CryptoHelper::DecryptFinalRelaxed(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
+{
     *outl = 0;
 
-    b=ctx->cipher->block_size;
-    if (ctx->flags & EVP_CIPH_NO_PADDING) {
-        if(ctx->buf_len) {
+    const int b = EVP_CIPHER_CTX_block_size(ctx);
+    if (EVP_CIPHER_CTX_test_flags(ctx, EVP_CIPH_NO_PADDING)) {
+        if(buf_len) {
             PTRACE(1, "H235\tDecrypt error: data not a multiple of block length");
             return 0;
         }
-        *outl = 0;
         return 1;
     }
     if (b > 1) {
-        if (ctx->buf_len || !ctx->final_used) {
+        if (buf_len || !final_used) {
             PTRACE(1, "H235\tDecrypt error: wrong final block length");
-            return(0);
+            return 0;
         }
-        OPENSSL_assert(b <= sizeof ctx->final);
-        int n=ctx->final[b-1];
+        OPENSSL_assert(b <= (int)sizeof(final_buf));
+        int n = final_buf[b-1];
         if (n == 0 || n > (int)b) {
             PTRACE(1, "H235\tDecrypt error: bad decrypt");
-            return(0);
+            return 0;
         }
         // Polycom endpoints (eg. m100 and PVX) don't fill the padding propperly, so we have to disable this check
 /*
         for (int i=0; i<n; i++) {
-            if (ctx->final[--b] != n) {
+            if (final_buf[--b] != n) {
                 PTRACE(1, "H235\tDecrypt error: incorrect padding");
-                return(0);
+                return 0;
             }
         }
 */
-        n=ctx->cipher->block_size-n;
+        n = b - n;
         for (int i=0; i<n; i++)
-            out[i]=ctx->final[i];
-        *outl=n;
+            out[i]=final_buf[i];
+        *outl = n;
     }
-    else
-        *outl=0;
-    return(1);
+    return 1;
 }
 
 H235CryptoEngine::H235CryptoEngine(const PString & algorithmOID)
-:  m_algorithmOID(algorithmOID), m_operationCnt(0), m_initialised(false),
+:  m_encryptCtx(NULL), m_decryptCtx(NULL),
+   m_algorithmOID(algorithmOID), m_operationCnt(0), m_initialised(false),
    m_enc_blockSize(0), m_enc_ivLength(0), m_dec_blockSize(0), m_dec_ivLength(0)
 {
 }
 
 H235CryptoEngine::H235CryptoEngine(const PString & algorithmOID, const PBYTEArray & key)
-:  m_algorithmOID(algorithmOID), m_operationCnt(0), m_initialised(false),
+:  m_encryptCtx(NULL), m_decryptCtx(NULL),
+   m_algorithmOID(algorithmOID), m_operationCnt(0), m_initialised(false),
    m_enc_blockSize(0), m_enc_ivLength(0), m_dec_blockSize(0), m_dec_ivLength(0)
 {
     SetKey(key);
@@ -352,10 +377,10 @@ H235CryptoEngine::H235CryptoEngine(const PString & algorithmOID, const PBYTEArra
 
 H235CryptoEngine::~H235CryptoEngine()
 {
-    if (m_initialised) {
-        EVP_CIPHER_CTX_cleanup(&m_encryptCtx);
-        EVP_CIPHER_CTX_cleanup(&m_decryptCtx);
-    }
+    if (m_encryptCtx != NULL)
+      EVP_CIPHER_CTX_free(m_encryptCtx);
+    if (m_decryptCtx != NULL)
+      EVP_CIPHER_CTX_free(m_decryptCtx);
 }
 
 void H235CryptoEngine::SetKey(PBYTEArray key)
@@ -375,15 +400,47 @@ void H235CryptoEngine::SetKey(PBYTEArray key)
         return;
     }
 
-    EVP_CIPHER_CTX_init(&m_encryptCtx);
-    EVP_EncryptInit_ex(&m_encryptCtx, cipher, NULL, key.GetPointer(), NULL);
-    m_enc_blockSize =  EVP_CIPHER_CTX_block_size(&m_encryptCtx);
-    m_enc_ivLength = EVP_CIPHER_CTX_iv_length(&m_encryptCtx);
+    m_initialised = false;
 
-    EVP_CIPHER_CTX_init(&m_decryptCtx);
-    EVP_DecryptInit_ex(&m_decryptCtx, cipher, NULL, key.GetPointer(), NULL);
-    m_dec_blockSize =  EVP_CIPHER_CTX_block_size(&m_decryptCtx);
-    m_dec_ivLength = EVP_CIPHER_CTX_iv_length(&m_decryptCtx);
+    if (m_encryptCtx == NULL) {
+      m_encryptCtx = EVP_CIPHER_CTX_new();
+      if (m_encryptCtx == NULL) {
+        PTRACE(1, "H235\tFailed to allocate EVP encrypt context");
+        return;
+      }
+    } else {
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
+      EVP_CIPHER_CTX_cleanup(m_encryptCtx);
+      EVP_CIPHER_CTX_init(m_encryptCtx);
+#else
+      EVP_CIPHER_CTX_reset(m_encryptCtx);
+#endif
+    }
+
+    EVP_EncryptInit_ex(m_encryptCtx, cipher, NULL, key.GetPointer(), NULL);
+    m_enc_blockSize =  EVP_CIPHER_CTX_block_size(m_encryptCtx);
+    m_enc_ivLength = EVP_CIPHER_CTX_iv_length(m_encryptCtx);
+    m_encryptHelper.Reset();
+
+    if (m_decryptCtx == NULL) {
+      m_decryptCtx = EVP_CIPHER_CTX_new();
+      if (m_decryptCtx == NULL) {
+        PTRACE(1, "H235\tFailed to allocate EVP decrypt context");
+        return;
+      }
+    } else {
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
+      EVP_CIPHER_CTX_cleanup(m_decryptCtx);
+      EVP_CIPHER_CTX_init(m_decryptCtx);
+#else
+      EVP_CIPHER_CTX_reset(m_decryptCtx);
+#endif
+    }
+
+    EVP_DecryptInit_ex(m_decryptCtx, cipher, NULL, key.GetPointer(), NULL);
+    m_dec_blockSize =  EVP_CIPHER_CTX_block_size(m_decryptCtx);
+    m_dec_ivLength = EVP_CIPHER_CTX_iv_length(m_decryptCtx);
+    m_decryptHelper.Reset();
 
     m_operationCnt = 0;
     m_initialised = true;
@@ -414,40 +471,37 @@ PBYTEArray H235CryptoEngine::Encrypt(const PBYTEArray & _data, unsigned char * i
     unsigned char iv[EVP_MAX_IV_LENGTH];
 
     // max ciphertext len for a n bytes of plaintext is n + BLOCK_SIZE -1 bytes
-    int ciphertext_len = data.GetSize() + EVP_CIPHER_CTX_block_size(&m_encryptCtx);
+    int ciphertext_len = data.GetSize() + EVP_CIPHER_CTX_block_size(m_encryptCtx);
     int final_len = 0;
     PBYTEArray ciphertext(ciphertext_len);
 
-    SetIV(iv, ivSequence, EVP_CIPHER_CTX_iv_length(&m_encryptCtx));
-    EVP_EncryptInit_ex(&m_encryptCtx, NULL, NULL, NULL, iv);
+    SetIV(iv, ivSequence, EVP_CIPHER_CTX_iv_length(m_encryptCtx));
+    EVP_EncryptInit_ex(m_encryptCtx, NULL, NULL, NULL, iv);
+    m_encryptHelper.Reset();
 
     // always use padding, because our ciphertext stealing implementation
     // doesn't seem to produce compatible results
-    //rtpPadding = (data.GetSize() < EVP_CIPHER_CTX_block_size(&m_encryptCtx));  // not interoperable!
-    rtpPadding = (data.GetSize() % EVP_CIPHER_CTX_block_size(&m_encryptCtx) > 0);
-    EVP_CIPHER_CTX_set_padding(&m_encryptCtx, rtpPadding ? 1 : 0);
+    //rtpPadding = (data.GetSize() < EVP_CIPHER_CTX_block_size(m_encryptCtx));  // not interoperable!
+    rtpPadding = (data.GetSize() % EVP_CIPHER_CTX_block_size(m_encryptCtx) > 0);
+    EVP_CIPHER_CTX_set_padding(m_encryptCtx, rtpPadding ? 1 : 0);
 
-    if (!rtpPadding && (data.GetSize() % EVP_CIPHER_CTX_block_size(&m_encryptCtx) > 0)) {
+    if (!rtpPadding && (data.GetSize() % EVP_CIPHER_CTX_block_size(m_encryptCtx) > 0)) {
         // use cyphertext stealing
-        if (!EVP_EncryptUpdate_cts(&m_encryptCtx, ciphertext.GetPointer(), &ciphertext_len, data.GetPointer(), data.GetSize())) {
+        if (!m_encryptHelper.EncryptUpdateCTS(m_encryptCtx, ciphertext.GetPointer(), &ciphertext_len, data.GetPointer(), data.GetSize())) {
             PTRACE(1, "H235\tEVP_EncryptUpdate_cts() failed");
         }
-#if PTLIB_VER >= 2130
-        if (!EVP_EncryptFinal_ctsA(&m_encryptCtx, ciphertext.GetPointer() + ciphertext_len, &final_len)) {
-#else
-        if (!EVP_EncryptFinal_cts(&m_encryptCtx, ciphertext.GetPointer() + ciphertext_len, &final_len)) {
-#endif
+        if (!m_encryptHelper.EncryptFinalCTS(m_encryptCtx, ciphertext.GetPointer() + ciphertext_len, &final_len)) {
             PTRACE(1, "H235\tEVP_EncryptFinal_cts() failed");
         }
     } else {
         /* update ciphertext, ciphertext_len is filled with the length of ciphertext generated,
          *len is the size of plaintext in bytes */
-        if (!EVP_EncryptUpdate(&m_encryptCtx, ciphertext.GetPointer(), &ciphertext_len, data.GetPointer(), data.GetSize())) {
+        if (!EVP_EncryptUpdate(m_encryptCtx, ciphertext.GetPointer(), &ciphertext_len, data.GetPointer(), data.GetSize())) {
             PTRACE(1, "H235\tEVP_EncryptUpdate() failed");
         }
 
         // update ciphertext with the final remaining bytes, if any use RTP padding
-        if (!EVP_EncryptFinal_ex(&m_encryptCtx, ciphertext.GetPointer() + ciphertext_len, &final_len)) {
+        if (!EVP_EncryptFinal_ex(m_encryptCtx, ciphertext.GetPointer() + ciphertext_len, &final_len)) {
             PTRACE(1, "H235\tEVP_EncryptFinal_ex() failed");
         }
     }
@@ -470,32 +524,29 @@ PINDEX H235CryptoEngine::EncryptInPlace(const BYTE * inData, PINDEX inLength, BY
     int inSize =  inLength + m_enc_blockSize;
 
     SetIV(m_iv, ivSequence, m_enc_ivLength);
-    EVP_EncryptInit_ex(&m_encryptCtx, NULL, NULL, NULL, m_iv);
+    EVP_EncryptInit_ex(m_encryptCtx, NULL, NULL, NULL, m_iv);
+    m_encryptHelper.Reset();
 
     rtpPadding = (inLength % m_enc_blockSize > 0);
-    EVP_CIPHER_CTX_set_padding(&m_encryptCtx, rtpPadding ? 1 : 0);
+    EVP_CIPHER_CTX_set_padding(m_encryptCtx, rtpPadding ? 1 : 0);
 
     if (!rtpPadding && (inLength % m_enc_blockSize > 0)) {
         // use cyphertext stealing
-        if (!EVP_EncryptUpdate_cts(&m_encryptCtx, outData, &inSize, inData, inLength)) {
+        if (!m_encryptHelper.EncryptUpdateCTS(m_encryptCtx, outData, &inSize, inData, inLength)) {
             PTRACE(1, "H235\tEVP_EncryptUpdate_cts() failed");
         }
-#if PTLIB_VER >= 2130
-        if (!EVP_EncryptFinal_ctsA(&m_encryptCtx, outData + inSize, &outSize)) {
-#else
-        if (!EVP_EncryptFinal_cts(&m_encryptCtx, outData + inSize, &outSize)) {
-#endif
+        if (!m_encryptHelper.EncryptFinalCTS(m_encryptCtx, outData + inSize, &outSize)) {
             PTRACE(1, "H235\tEVP_EncryptFinal_cts() failed");
         }
     } else {
         /* update ciphertext, ciphertext_len is filled with the length of ciphertext generated,
          *len is the size of plaintext in bytes */
-        if (!EVP_EncryptUpdate(&m_encryptCtx, outData, &inSize, inData, inLength)) {
+        if (!EVP_EncryptUpdate(m_encryptCtx, outData, &inSize, inData, inLength)) {
             PTRACE(1, "H235\tEVP_EncryptUpdate() failed");
         }
 
         // update ciphertext with the final remaining bytes, if any use RTP padding
-        if (!EVP_EncryptFinal_ex(&m_encryptCtx, outData + inSize, &outSize)) {
+        if (!EVP_EncryptFinal_ex(m_encryptCtx, outData + inSize, &outSize)) {
             PTRACE(1, "H235\tEVP_EncryptFinal_ex() failed");
         }
     }
@@ -515,24 +566,25 @@ PBYTEArray H235CryptoEngine::Decrypt(const PBYTEArray & _data, unsigned char * i
     int final_len = 0;
     PBYTEArray plaintext(plaintext_len);
 
-    SetIV(iv, ivSequence, EVP_CIPHER_CTX_iv_length(&m_decryptCtx));
-    EVP_DecryptInit_ex(&m_decryptCtx, NULL, NULL, NULL, iv);
+    SetIV(iv, ivSequence, EVP_CIPHER_CTX_iv_length(m_decryptCtx));
+    EVP_DecryptInit_ex(m_decryptCtx, NULL, NULL, NULL, iv);
+    m_decryptHelper.Reset();
 
-    EVP_CIPHER_CTX_set_padding(&m_decryptCtx, rtpPadding ? 1 : 0);
+    EVP_CIPHER_CTX_set_padding(m_decryptCtx, rtpPadding ? 1 : 0);
 
-    if (!rtpPadding && data.GetSize() % EVP_CIPHER_CTX_block_size(&m_decryptCtx) > 0) {
+    if (!rtpPadding && data.GetSize() % EVP_CIPHER_CTX_block_size(m_decryptCtx) > 0) {
         // use cyphertext stealing
-        if (!EVP_DecryptUpdate_cts(&m_decryptCtx, plaintext.GetPointer(), &plaintext_len, data.GetPointer(), data.GetSize())) {
+        if (!m_decryptHelper.DecryptUpdateCTS(m_decryptCtx, plaintext.GetPointer(), &plaintext_len, data.GetPointer(), data.GetSize())) {
             PTRACE(1, "H235\tEVP_DecryptUpdate_cts() failed");
         }
-        if(!EVP_DecryptFinal_cts(&m_decryptCtx, plaintext.GetPointer() + plaintext_len, &final_len)) {
+        if(!m_decryptHelper.DecryptFinalCTS(m_decryptCtx, plaintext.GetPointer() + plaintext_len, &final_len)) {
             PTRACE(1, "H235\tEVP_DecryptFinal_cts() failed");
         }
     } else {
-        if (!EVP_DecryptUpdate(&m_decryptCtx, plaintext.GetPointer(), &plaintext_len, data.GetPointer(), data.GetSize())) {
+        if (!m_decryptHelper.DecryptUpdate(m_decryptCtx, plaintext.GetPointer(), &plaintext_len, data.GetPointer(), data.GetSize())) {
             PTRACE(1, "H235\tEVP_DecryptUpdate() failed");
         }
-        if (!EVP_DecryptFinal_relaxed(&m_decryptCtx, plaintext.GetPointer() + plaintext_len, &final_len)) {
+        if (!m_decryptHelper.DecryptFinalRelaxed(m_decryptCtx, plaintext.GetPointer() + plaintext_len, &final_len)) {
             PTRACE(1, "H235\tEVP_DecryptFinal_ex() failed - incorrect padding ?");
         }
     }
@@ -551,26 +603,27 @@ PINDEX H235CryptoEngine::DecryptInPlace(const BYTE * inData, PINDEX inLength, BY
     int inSize =  inLength;
 
     SetIV(m_iv, ivSequence, m_dec_ivLength);
-    EVP_DecryptInit_ex(&m_decryptCtx, NULL, NULL, NULL, m_iv);
+    EVP_DecryptInit_ex(m_decryptCtx, NULL, NULL, NULL, m_iv);
+    m_decryptHelper.Reset();
 
-    EVP_CIPHER_CTX_set_padding(&m_decryptCtx, rtpPadding ? 1 : 0);
+    EVP_CIPHER_CTX_set_padding(m_decryptCtx, rtpPadding ? 1 : 0);
 
     if (!rtpPadding && inLength % m_dec_blockSize > 0) {
         // use cyphertext stealing
-        if (!EVP_DecryptUpdate_cts(&m_decryptCtx, outData, &inSize, inData, inLength)) {
+        if (!m_decryptHelper.DecryptUpdateCTS(m_decryptCtx, outData, &inSize, inData, inLength)) {
             PTRACE(1, "H235\tEVP_DecryptUpdate_cts() failed");
 			return 0;	// no usable payload
         }
-        if(!EVP_DecryptFinal_cts(&m_decryptCtx, outData + inSize, &outSize)) {
+        if(!m_decryptHelper.DecryptFinalCTS(m_decryptCtx, outData + inSize, &outSize)) {
             PTRACE(1, "H235\tEVP_DecryptFinal_cts() failed");
 			return 0;	// no usable payload
         }
     } else {
-        if (!EVP_DecryptUpdate(&m_decryptCtx, outData, &inSize, inData, inLength)) {
+        if (!m_decryptHelper.DecryptUpdate(m_decryptCtx, outData, &inSize, inData, inLength)) {
             PTRACE(1, "H235\tEVP_DecryptUpdate() failed");
 			return 0;	// no usable payload
         }
-        if (!EVP_DecryptFinal_relaxed(&m_decryptCtx, outData + inSize, &outSize)) {
+        if (!m_decryptHelper.DecryptFinalRelaxed(m_decryptCtx, outData + inSize, &outSize)) {
             PTRACE(1, "H235\tEVP_DecryptFinal_ex() failed - incorrect padding ?");
 			return 0;	// no usable payload
         }

--- a/src/h235/h235support.cxx
+++ b/src/h235/h235support.cxx
@@ -48,11 +48,86 @@
 #include <ptclib/cypher.h>
 
 extern "C" {
+#include <openssl/opensslv.h>
 #include <openssl/err.h>
 #include <openssl/dh.h>
 #include <openssl/pem.h>
 #include <openssl/bn.h>
 };
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+
+inline void DH_get0_pqg(const DH *dh,
+                 const BIGNUM **p, const BIGNUM **q, const BIGNUM **g)
+{
+    if (p != NULL)
+        *p = dh->p;
+    if (q != NULL)
+        *q = dh->q;
+    if (g != NULL)
+        *g = dh->g;
+}
+
+inline int DH_set0_pqg(DH *dh, BIGNUM *p, BIGNUM *q, BIGNUM *g)
+{
+    /* If the fields p and g in d are NULL, the corresponding input
+     * parameters MUST be non-NULL.  q may remain NULL.
+     */
+    if ((dh->p == NULL && p == NULL)
+        || (dh->g == NULL && g == NULL))
+        return 0;
+
+    if (p != NULL) {
+        BN_free(dh->p);
+        dh->p = p;
+    }
+    if (q != NULL) {
+        BN_free(dh->q);
+        dh->q = q;
+    }
+    if (g != NULL) {
+        BN_free(dh->g);
+        dh->g = g;
+    }
+
+    if (q != NULL) {
+        dh->length = BN_num_bits(q);
+    }
+
+    return 1;
+}
+
+inline void DH_get0_key(const DH *dh, const BIGNUM **pub_key, const BIGNUM **priv_key)
+{
+    if (pub_key != NULL)
+        *pub_key = dh->pub_key;
+    if (priv_key != NULL)
+        *priv_key = dh->priv_key;
+}
+
+inline int DH_set0_key(DH *dh, BIGNUM *pub_key, BIGNUM *priv_key)
+{
+    /* If the field pub_key in dh is NULL, the corresponding input
+     * parameters MUST be non-NULL.  The priv_key field may
+     * be left NULL.
+     */
+    if (dh->pub_key == NULL && pub_key == NULL)
+        return 0;
+
+    if (pub_key != NULL) {
+        BN_free(dh->pub_key);
+        dh->pub_key = pub_key;
+    }
+    if (priv_key != NULL) {
+        BN_free(dh->priv_key);
+        dh->priv_key = priv_key;
+    }
+
+    return 1;
+}
+
+#endif // OPENSSL_VERSION_NUMBER < 0x10100000L
+
 
 ////////////////////////////////////////////////////////////////////////////////////
 // Diffie Hellman
@@ -61,10 +136,13 @@ H235_DiffieHellman::H235_DiffieHellman(const PConfig  & dhFile, const PString & 
 : dh(NULL), m_remKey(NULL), m_toSend(true), m_wasReceived(false), m_wasDHReceived(false), m_keySize(0), m_loadFromFile(false)
 {
   if (Load(dhFile, section)) {
-    if (dh->pub_key == NULL) {
+    const BIGNUM *pub_key = NULL;
+    DH_get0_key(dh, &pub_key, NULL);
+    if (pub_key == NULL) {
       GenerateHalfKey();
+      DH_get0_key(dh, &pub_key, NULL);
     }
-    m_keySize = BN_num_bytes(dh->pub_key);
+    m_keySize = BN_num_bytes(pub_key);
   }
 }
 
@@ -77,7 +155,9 @@ H235_DiffieHellman::H235_DiffieHellman(const PFilePath & dhPKCS3)
         dh = PEM_read_DHparams(paramfile, NULL, NULL, NULL);
         fclose(paramfile);
         if (dh) {
-            m_keySize = BN_num_bits(dh->p);
+            const BIGNUM* dh_p = NULL;
+            DH_get0_pqg(dh, &dh_p, NULL, NULL);
+            m_keySize = BN_num_bits(dh_p);
             m_loadFromFile = true;
         }
     }
@@ -94,13 +174,18 @@ H235_DiffieHellman::H235_DiffieHellman(const BYTE * pData, PINDEX pSize,
     return;
   };
 
-    dh->p = BN_bin2bn(pData, pSize, NULL);
-    dh->g = BN_bin2bn(gData, gSize, NULL);
-    if (dh->p != NULL && dh->g != NULL) {
+    BIGNUM* p = BN_bin2bn(pData, pSize, NULL);
+    BIGNUM* g = BN_bin2bn(gData, gSize, NULL);
+    if (p != NULL && g != NULL) {
+        DH_set0_pqg(dh, p, NULL, g);
         GenerateHalfKey();
         return;
     }
 
+    if (g)
+        BN_free(g);
+    if (p)
+        BN_free(p);
     PTRACE(1, "H235_DH\tFailed to generate half key");
     DH_free(dh);
     dh = NULL;
@@ -115,16 +200,24 @@ static DH * DH_dup(const DH * dh)
   if (ret == NULL)
     return NULL;
 
-  if (dh->p)
-    ret->p = BN_dup(dh->p);
-  if (dh->q)
-    ret->q = BN_dup(dh->q);
-  if (dh->g)
-    ret->g = BN_dup(dh->g);
-  if (dh->pub_key)
-    ret->pub_key = BN_dup(dh->pub_key);
-  if (dh->priv_key)
-    ret->priv_key = BN_dup(dh->priv_key);
+  const BIGNUM *p = NULL, *q = NULL, *g = NULL;
+  DH_get0_pqg(dh, &p, &q, &g);
+
+  if (p)
+    p = BN_dup(p);
+  if (q)
+    q = BN_dup(q);
+  if (g)
+    g = BN_dup(g);
+  DH_set0_pqg(ret, const_cast< BIGNUM* >(p), const_cast< BIGNUM* >(q), const_cast< BIGNUM* >(g));
+
+  const BIGNUM *pub_key = NULL, *priv_key = NULL;
+  DH_get0_key(dh, &pub_key, &priv_key);
+  if (pub_key)
+    pub_key = BN_dup(pub_key);
+  if (priv_key)
+    priv_key = BN_dup(priv_key);
+  DH_set0_key(ret, const_cast< BIGNUM* >(pub_key), const_cast< BIGNUM* >(priv_key));
 
   return ret;
 }
@@ -202,11 +295,14 @@ PBoolean H235_DiffieHellman::Encode_P(PASN_BitString & p) const
   if (!m_toSend)
     return false;
 
-  unsigned char * data = (unsigned char *)OPENSSL_malloc(BN_num_bytes(dh->p));
+  const BIGNUM *dh_p = NULL;
+  DH_get0_pqg(dh, &dh_p, NULL, NULL);
+
+  unsigned char * data = (unsigned char *)OPENSSL_malloc(BN_num_bytes(dh_p));
   if (data != NULL) {
-    memset(data, 0, BN_num_bytes(dh->p));
-    if (BN_bn2bin(dh->p, data) > 0) {
-       p.SetData(BN_num_bits(dh->p), data);
+    memset(data, 0, BN_num_bytes(dh_p));
+    if (BN_bn2bin(dh_p, data) > 0) {
+       p.SetData(BN_num_bits(dh_p), data);
     } else {
       PTRACE(1, "H235_DH\tFailed to encode P");
       OPENSSL_free(data);
@@ -223,10 +319,7 @@ void H235_DiffieHellman::Decode_P(const PASN_BitString & p)
     return;
 
   PWaitAndSignal m(vbMutex);
-  const unsigned char * data = p.GetDataPointer();
-  if (dh->p)
-    BN_free(dh->p);
-  dh->p = BN_bin2bn(data, p.GetDataLength() - 1, NULL);
+  DH_set0_pqg(dh, BN_bin2bn(p.GetDataPointer(), p.GetDataLength() - 1, NULL), NULL, NULL);
 }
 
 PBoolean H235_DiffieHellman::Encode_G(PASN_BitString & g) const
@@ -235,17 +328,21 @@ PBoolean H235_DiffieHellman::Encode_G(PASN_BitString & g) const
         return false;
 
     PWaitAndSignal m(vbMutex);
-    int len_p = BN_num_bytes(dh->p);
-    int len_g = BN_num_bytes(dh->g);
-    int bits_p = BN_num_bits(dh->p);
-    //int bits_g = BN_num_bits(dh->g); // unused
+
+    const BIGNUM *dh_p = NULL, *dh_g = NULL;
+    DH_get0_pqg(dh, &dh_p, NULL, &dh_g);
+
+    int len_p = BN_num_bytes(dh_p);
+    int len_g = BN_num_bytes(dh_g);
+    int bits_p = BN_num_bits(dh_p);
+    //int bits_g = BN_num_bits(dh_g); // unused
 
     if (len_p <= 128) { // Key lengths <= 1024 bits
         // Backwards compatibility G is padded out to the length of P
         unsigned char * data = (unsigned char *)OPENSSL_malloc(len_p);
         if (data != NULL) {
             memset(data, 0, len_p);
-            if (BN_bn2bin(dh->g, data + len_p - len_g) > 0) {
+            if (BN_bn2bin(dh_g, data + len_p - len_g) > 0) {
                 g.SetData(bits_p, data);
             }
             else {
@@ -259,7 +356,7 @@ PBoolean H235_DiffieHellman::Encode_G(PASN_BitString & g) const
         unsigned char * data = (unsigned char *)OPENSSL_malloc(len_g);
         if (data != NULL) {
             memset(data, 0, len_g);
-            if (BN_bn2bin(dh->g, data) > 0) {
+            if (BN_bn2bin(dh_g, data) > 0) {
                 g.SetData(8, data);
             }
             else {
@@ -279,9 +376,7 @@ void H235_DiffieHellman::Decode_G(const PASN_BitString & g)
     return;
 
   PWaitAndSignal m(vbMutex);
-  if (dh->g)
-    BN_free(dh->g);
-  dh->g = BN_bin2bn(g.GetDataPointer(), g.GetDataLength() - 1, NULL);
+  DH_set0_pqg(dh, NULL, NULL, BN_bin2bn(g.GetDataPointer(), g.GetDataLength() - 1, NULL));
 }
 
 
@@ -289,9 +384,14 @@ void H235_DiffieHellman::Encode_HalfKey(PASN_BitString & hk) const
 {
   PWaitAndSignal m(vbMutex);
 
-  int len_p = BN_num_bytes(dh->p);
-  int len_key = BN_num_bytes(dh->pub_key);
-  int bits_p = BN_num_bits(dh->p);
+  const BIGNUM *dh_p = NULL;
+  DH_get0_pqg(dh, &dh_p, NULL, NULL);
+  const BIGNUM *pub_key = NULL;
+  DH_get0_key(dh, &pub_key, NULL);
+
+  int len_p = BN_num_bytes(dh_p);
+  int len_key = BN_num_bytes(pub_key);
+  int bits_p = BN_num_bits(dh_p);
 
   if (len_key > len_p) {
     PTRACE(1, "H235_DH\tFailed to encode halfkey: len key > len prime");
@@ -302,7 +402,7 @@ void H235_DiffieHellman::Encode_HalfKey(PASN_BitString & hk) const
   unsigned char * data = (unsigned char *)OPENSSL_malloc(len_p);
   if (data != NULL) {
     memset(data, 0, len_p);
-    if (BN_bn2bin(dh->pub_key, data + len_p - len_key) > 0) {
+    if (BN_bn2bin(pub_key, data + len_p - len_key) > 0) {
        hk.SetData(bits_p, data);
     } else {
       PTRACE(1, "H235_DH\tFailed to encode halfkey");
@@ -316,9 +416,7 @@ void H235_DiffieHellman::Decode_HalfKey(const PASN_BitString & hk)
   PWaitAndSignal m(vbMutex);
 
   const unsigned char *data = hk.GetDataPointer();
-  if (dh->pub_key)
-    BN_free(dh->pub_key);
-  dh->pub_key = BN_bin2bn(data, hk.GetDataLength() - 1, NULL);
+  DH_set0_key(dh, BN_bin2bn(data, hk.GetDataLength() - 1, NULL), NULL);
 }
 
 void H235_DiffieHellman::SetRemoteKey(bignum_st * remKey)
@@ -339,8 +437,12 @@ void H235_DiffieHellman::SetRemoteHalfKey(const PASN_BitString & hk)
 
 PBoolean H235_DiffieHellman::GenerateHalfKey()
 {
-  if (dh && dh->pub_key)
-    return true;
+  if (dh) {
+    const BIGNUM *pub_key = NULL;
+    DH_get0_key(dh, &pub_key, NULL);
+    if (pub_key)
+      return true;
+  }
 
   PWaitAndSignal m(vbMutex);
 
@@ -377,12 +479,14 @@ PBoolean H235_DiffieHellman::Load(const PConfig  & dhFile, const PString & secti
   PString str;
   PBYTEArray data;
 
+  BIGNUM *dh_p = NULL, *dh_g = NULL, *pub_key = NULL, *priv_key = NULL;
+
   PBoolean ok = true;
   if (dhFile.HasKey(section, "PRIME")) {
     str = dhFile.GetString(section, "PRIME", "");
     PBase64::Decode(str, data);
-    dh->p = BN_bin2bn(data.GetPointer(), data.GetSize(), NULL);
-    ok = ok && (BN_num_bytes(dh->p) > 0);
+    dh_p = BN_bin2bn(data.GetPointer(), data.GetSize(), NULL);
+    ok = ok && (BN_num_bytes(dh_p) > 0);
   } else 
     ok = false;
 
@@ -393,28 +497,54 @@ PBoolean H235_DiffieHellman::Load(const PConfig  & dhFile, const PString & secti
     memcpy(temp.GetPointer(), data.GetPointer(), 1);
     memset(data.GetPointer(), 0, data.GetSize());
     memcpy(data.GetPointer() + data.GetSize()-1, temp.GetPointer(), 1);
-    dh->g = BN_bin2bn(data.GetPointer(), data.GetSize(), NULL);
-    ok = ok && (BN_num_bytes(dh->g) > 0);
+    dh_g = BN_bin2bn(data.GetPointer(), data.GetSize(), NULL);
+    ok = ok && (BN_num_bytes(dh_g) > 0);
   } else 
     ok = false;
 
   if (dhFile.HasKey(section, "PUBLIC")) {
     str = dhFile.GetString(section, "PUBLIC", "");
     PBase64::Decode(str, data);
-    dh->pub_key = BN_bin2bn(data.GetPointer(), data.GetSize(), NULL);
-    ok = ok && (BN_num_bytes(dh->pub_key) > 0);
+    pub_key = BN_bin2bn(data.GetPointer(), data.GetSize(), NULL);
+    ok = ok && (BN_num_bytes(pub_key) > 0);
   }
   
   if (dhFile.HasKey(section, "PRIVATE")) {
     str = dhFile.GetString(section, "PRIVATE", "");
     PBase64::Decode(str, data);
-    dh->priv_key = BN_bin2bn(data.GetPointer(), data.GetSize(), NULL);
-    ok = ok && (BN_num_bytes(dh->priv_key) > 0);
+    priv_key = BN_bin2bn(data.GetPointer(), data.GetSize(), NULL);
+    ok = ok && (BN_num_bytes(priv_key) > 0);
+  }
+
+  if (ok) {
+    if (DH_set0_pqg(dh, dh_p, NULL, dh_g)) {
+      dh_p = NULL;
+      dh_g = NULL;
+    } else {
+      ok = false;
+    }
+  }
+
+  if (ok) {
+    if (DH_set0_key(dh, pub_key, priv_key)) {
+      pub_key = NULL;
+      priv_key = NULL;
+    } else {
+      ok = false;
+    }
   }
 
   if (ok /*&& CheckParams()*/) 
     m_loadFromFile = true;
   else {
+    if (priv_key)
+      BN_free(priv_key);
+    if (pub_key)
+      BN_free(pub_key);
+    if (dh_g)
+      BN_free(dh_g);
+    if (dh_p)
+      BN_free(dh_p);
     DH_free(dh);
     dh = NULL;
   } 
@@ -429,36 +559,44 @@ PBoolean H235_DiffieHellman::LoadedFromFile()
 
 PBoolean H235_DiffieHellman::Save(const PFilePath & dhFile, const PString & oid)
 {
-  if (!dh || !dh->pub_key)
+  if (!dh)
     return false;
+
+  const BIGNUM *pub_key = NULL, *priv_key = NULL;
+  DH_get0_key(dh, &pub_key, &priv_key);
+  if (!pub_key)
+    return false;
+
+  const BIGNUM *dh_p = NULL, *dh_g = NULL;
+  DH_get0_pqg(dh, &dh_p, NULL, &dh_g);
 
   PConfig config(dhFile, oid);
   PString str = PString();
-  int len = BN_num_bytes(dh->pub_key);
+  int len = BN_num_bytes(pub_key);
   unsigned char * data = (unsigned char *)OPENSSL_malloc(len); 
 
-  if (data != NULL && BN_bn2bin(dh->p, data) > 0) {
+  if (data != NULL && BN_bn2bin(dh_p, data) > 0) {
     str = PBase64::Encode(data, len, "");
     config.SetString("PRIME",str);
   }
   OPENSSL_free(data);
 
   data = (unsigned char *)OPENSSL_malloc(len); 
-  if (data != NULL && BN_bn2bin(dh->g, data) > 0) {
+  if (data != NULL && BN_bn2bin(dh_g, data) > 0) {
     str = PBase64::Encode(data, len, "");
     config.SetString("GENERATOR",str);
   }
   OPENSSL_free(data);
 
   data = (unsigned char *)OPENSSL_malloc(len); 
-  if (data != NULL && BN_bn2bin(dh->pub_key, data) > 0) {
+  if (data != NULL && BN_bn2bin(pub_key, data) > 0) {
     str = PBase64::Encode(data, len, "");
     config.SetString("PUBLIC",str);
   }
   OPENSSL_free(data);
 
   data = (unsigned char *)OPENSSL_malloc(len); 
-  if (data != NULL && BN_bn2bin(dh->priv_key, data) > 0) {
+  if (data != NULL && BN_bn2bin(priv_key, data) > 0) {
     PString str = PBase64::Encode(data, len, "");
     config.SetString("PRIVATE",str);
   }
@@ -494,7 +632,9 @@ PBoolean H235_DiffieHellman::ComputeSessionKey(PBYTEArray & SessionKey)
 
 bignum_st * H235_DiffieHellman::GetPublicKey() const
 {
-  return dh->pub_key;
+  const BIGNUM *pub_key = NULL;
+  DH_get0_key(dh, &pub_key, NULL);
+  return const_cast< BIGNUM* >(pub_key);
 }
 
 int H235_DiffieHellman::GetKeyLength() const
@@ -525,19 +665,22 @@ void H235_DiffieHellman::Generate(PINDEX keyLength, PINDEX keyGenerator, PString
 
     parameters.SetAt("OID", lOID);
 
+    const BIGNUM *vdh_p = NULL, *vdh_g = NULL;
+    DH_get0_pqg(vdh, &vdh_p, NULL, &vdh_g);
+
     PString str = PString();
-    int len = BN_num_bytes(vdh->p);
+    int len = BN_num_bytes(vdh_p);
     unsigned char * data = (unsigned char *)OPENSSL_malloc(len);
 
-    if (data != NULL && BN_bn2bin(vdh->p, data) > 0) {
+    if (data != NULL && BN_bn2bin(vdh_p, data) > 0) {
         str = PBase64::Encode(data, len, "");
         parameters.SetAt("PRIME", str);
     }
     OPENSSL_free(data);
 
-    len = BN_num_bytes(vdh->g);
+    len = BN_num_bytes(vdh_g);
     data = (unsigned char *)OPENSSL_malloc(len);
-    if (data != NULL && BN_bn2bin(vdh->g, data) > 0) {
+    if (data != NULL && BN_bn2bin(vdh_g, data) > 0) {
         str = PBase64::Encode(data, len, "");
         parameters.SetAt("GENERATOR", str);
     }

--- a/src/transports.cxx
+++ b/src/transports.cxx
@@ -50,6 +50,7 @@
 #endif
 
 #ifdef H323_TLS
+#include <openssl/opensslv.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 #endif
@@ -1398,7 +1399,9 @@ void H323ListenerTCP::Main()
       new H225TransportThread(endpoint, transport);
   }
 #ifdef P_SSL
-  ERR_remove_state(0);
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
+  ERR_remove_thread_state(NULL);
+#endif
 #endif
 }
 


### PR DESCRIPTION
This is a more complete solution than https://github.com/willamowius/h323plus/pull/1.

This commit adds compatibility with OpenSSL 1.1. In h235 implementation,
CTS crypto engine has been reworked as a helper class which stores the
necessary cipher members that are not available publicly in OpenSSL 1.1
locally. In other places, added OpenSSL 1.1 API equivalents to use with
older OpenSSL versions.

Updated thread cleanup on older OpenSSL versions to use ERR_remove_thread_state.
On OpenSSL 1.1 no cleanup is needed as the library does it itself.

In TLS context initialization also disable TLS compression as it is vulnerable
to CRIME.