### PR TITLE
Add support for OpenSSL 1.1.0 to h235.

### DIFF
--- a/include/h235/h235crypto.h
+++ b/include/h235/h235crypto.h
@@ -44,18 +44,48 @@ extern "C" {
 #include <openssl/evp.h>
 }
 
-// H.235.6 says no more than 2^62 blocks, Schneier says no more than 2^32 blocks in CBC mode
+// H.235.6 says no more than 2^62 blocks, Bruce Schneier says no more than 2^32 blocks in CBC mode
 #define AES_KEY_LIMIT 4294967295U	// 2^32-1
 
 // helper routines not present in OpenSSL
-int EVP_EncryptUpdate_cts(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
-                      const unsigned char *in, int inl);
-int EVP_EncryptFinal_cts(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl);
-int EVP_DecryptUpdate_cts(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
-                      const unsigned char *in, int inl);
-int EVP_DecryptFinal_cts(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl);
-int EVP_DecryptFinal_relaxed(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl);
+class H235CryptoHelper
+{
+private:
+  //! Saved partial block of input data
+  unsigned char buf[EVP_MAX_BLOCK_LENGTH];
+  //! Last processed block of output data
+  unsigned char final_buf[EVP_MAX_BLOCK_LENGTH];
+  //! Number of bytes in buf
+  int buf_len;
+  //! Indicates whether the final buffer is used
+  int final_used;
 
+public:
+  H235CryptoHelper();
+
+  void Reset();
+
+  // Ciphertext stealing (CTS) methods
+  int EncryptUpdateCTS(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
+                       const unsigned char *in, int inl);
+  int EncryptFinalCTS(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl);
+  int DecryptUpdateCTS(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
+                       const unsigned char *in, int inl);
+  int DecryptFinalCTS(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl);
+
+  // Relaxed decryption that doesn't verify contents of the padding in the last decrypted block
+  int DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
+                    const unsigned char *in, int inl);
+  int DecryptFinalRelaxed(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl);
+
+private:
+  H235CryptoHelper(H235CryptoHelper const&);
+  H235CryptoHelper& operator= (H235CryptoHelper const&);
+
+  // Encryption algorithm only used as part of the decryption implementation
+  int EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
+                    const unsigned char *in, int inl);
+};
 
 class H235CryptoEngine : public PObject
 {
@@ -101,7 +131,7 @@ public:
 
     PBYTEArray GenerateRandomKey(const PString & algorithmOID);  // Use assigned Algorithm
 
-	PString GetAlgorithmOID() const { return m_algorithmOID; }
+    PString GetAlgorithmOID() const { return m_algorithmOID; }
 
     PBoolean IsMaxBlocksPerKeyReached() const { return m_operationCnt > AES_KEY_LIMIT; }
     void ResetBlockCount() { m_operationCnt = 0; }
@@ -109,7 +139,8 @@ public:
 protected:
     static void SetIV(unsigned char * iv, unsigned char * ivSequence, unsigned ivLen);
 
-    EVP_CIPHER_CTX m_encryptCtx, m_decryptCtx;
+    EVP_CIPHER_CTX *m_encryptCtx, *m_decryptCtx;
+    H235CryptoHelper m_encryptHelper, m_decryptHelper;
     PString m_algorithmOID;    // eg. "2.16.840.1.101.3.4.1.2"
     PUInt64 m_operationCnt;  // 8 byte integer
     PBoolean m_initialised;
@@ -182,7 +213,7 @@ public:
     PBoolean WriteFrameInPlace(RTP_DataFrame & frame);
   //@}
 
-	PString GetAlgorithmOID() const { return m_context.GetAlgorithmOID(); }
+    PString GetAlgorithmOID() const { return m_context.GetAlgorithmOID(); }
 
 private:
     H235_DiffieHellman & m_dh;

--- a/src/h235/h235crypto.cxx
+++ b/src/h235/h235crypto.cxx
@@ -35,6 +35,7 @@
  *
  */
 
+#include <string.h>
 #include <ptlib.h>
 #include "openh323buildopts.h"
 
@@ -44,8 +45,11 @@
 #include "h235/h235crypto.h"
 #include "h235/h235caps.h"
 #include "h235/h235support.h"
+extern "C" {
+#include <openssl/opensslv.h>
+#include <openssl/evp.h>
 #include <openssl/rand.h>
-
+}
 #include "rtp.h"
 
 #ifdef H323_H235_AES256
@@ -60,71 +64,96 @@
 // the IV sequence is always 6 bytes long (2 bytes seq number + 4 bytes timestamp)
 const unsigned int IV_SEQUENCE_LEN = 6;
 
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
 
-// ciphertext stealing code based on a OpenSSL patch by An-Cheng Huang
+inline const unsigned char *EVP_CIPHER_CTX_iv(const EVP_CIPHER_CTX *ctx)
+{
+    return ctx->iv;
+}
+
+#endif // (OPENSSL_VERSION_NUMBER < 0x10100000L)
+
+// Ciphertext stealing (CTS) code based on an OpenSSL patch by An-Cheng Huang
 // Note: This ciphertext stealing implementation doesn't seem to always produce
-// compatible results, avoid when encrypting:
+// compatible results, avoid when encrypting.
+// EncryptUpdate, DecryptUpdate and DecryptFinalRelaxed implementation is based
+// on the code from OpenSSL. These functions are implemented here for the sake of
+// a workaround for some broken terminals in DecryptFinalRelaxed.
+H235CryptoHelper::H235CryptoHelper()
+{
+    memset(buf, 0, sizeof(buf));
+    memset(final_buf, 0, sizeof(final_buf));
+    Reset();
+}
 
-int EVP_EncryptUpdate_cts(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
+inline void H235CryptoHelper::Reset()
+{
+    buf_len = 0;
+    final_used = 0;
+}
+
+int H235CryptoHelper::EncryptUpdateCTS(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
                       const unsigned char *in, int inl)
 {
-    int bl = ctx->cipher->block_size;
-    OPENSSL_assert(bl <= (int)sizeof(ctx->buf));
+    const int bl = EVP_CIPHER_CTX_block_size(ctx);
+    OPENSSL_assert(bl <= (int)sizeof(buf));
     *outl = 0;
 
-    if ((ctx->buf_len + inl) <= bl) {
+    if (inl <= 0)
+        return inl == 0;
+
+    if ((buf_len + inl) <= bl) {
         /* new plaintext is no more than 1 block */
         /* copy the in data into the buffer and return */
-        memcpy(&(ctx->buf[ctx->buf_len]), in, inl);
-        ctx->buf_len += inl;
-        *outl = 0;
+        memcpy(&(buf[buf_len]), in, inl);
+        buf_len += inl;
         return 1;
     }
 
     /* more than 1 block of new plaintext available */
     /* encrypt the previous plaintext, if any */
-    if (ctx->final_used) {
-        if (!(ctx->cipher->do_cipher(ctx, out, ctx->final, bl))) {
+    if (final_used) {
+        if (!(EVP_Cipher(ctx, out, final_buf, bl))) {
           return 0;
         }
         out += bl;
         *outl += bl;
-        ctx->final_used = 0;
+        final_used = 0;
     }
 
-    /* we already know ctx->buf_len + inl must be > bl */
-    memcpy(&(ctx->buf[ctx->buf_len]), in, (bl - ctx->buf_len));
-    in += (bl - ctx->buf_len);
-    inl -= (bl - ctx->buf_len);
-    ctx->buf_len = bl;
+    /* we already know buf_len + inl must be > bl */
+    memcpy(&(buf[buf_len]), in, (bl - buf_len));
+    in += (bl - buf_len);
+    inl -= (bl - buf_len);
+    buf_len = bl;
 
     if (inl <= bl) {
-        memcpy(ctx->final, ctx->buf, bl);
-        ctx->final_used = 1;
-        memcpy(ctx->buf, in, inl);
-        ctx->buf_len = inl;
+        memcpy(final_buf, buf, bl);
+        final_used = 1;
+        memcpy(buf, in, inl);
+        buf_len = inl;
         return 1;
     } else {
-        if (!(ctx->cipher->do_cipher(ctx, out, ctx->buf, bl))) {
+        if (!(EVP_Cipher(ctx, out, buf, bl))) {
             return 0;
         }
         out += bl;
         *outl += bl;
-        ctx->buf_len = 0;
+        buf_len = 0;
 
-        int leftover = inl & ctx->block_mask;
+        int leftover = inl & (bl - 1);
         if (leftover) {
             inl -= (bl + leftover);
-            memcpy(ctx->buf, &(in[(inl + bl)]), leftover);
-            ctx->buf_len = leftover;
+            memcpy(buf, &(in[(inl + bl)]), leftover);
+            buf_len = leftover;
         } else {
             inl -= (2 * bl);
-             memcpy(ctx->buf, &(in[(inl + bl)]), bl);
-             ctx->buf_len = bl;
+            memcpy(buf, &(in[(inl + bl)]), bl);
+            buf_len = bl;
         }
-        memcpy(ctx->final, &(in[inl]), bl);
-        ctx->final_used = 1;
-        if (!(ctx->cipher->do_cipher(ctx, out, in, inl))) {
+        memcpy(final_buf, &(in[inl]), bl);
+        final_used = 1;
+        if (!(EVP_Cipher(ctx, out, in, inl))) {
             return 0;
         }
         out += inl;
@@ -134,40 +163,36 @@ int EVP_EncryptUpdate_cts(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
     return 1;
 }
 
-#if PTLIB_VER >= 2130
-int EVP_EncryptFinal_ctsA(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
-#else
-int EVP_EncryptFinal_cts(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
-#endif
+int H235CryptoHelper::EncryptFinalCTS(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
 {
     unsigned char tmp[EVP_MAX_BLOCK_LENGTH];
-    int bl = ctx->cipher->block_size;
+    const int bl = EVP_CIPHER_CTX_block_size(ctx);
     int leftover = 0;
     *outl = 0;
 
-    if (!ctx->final_used) {
+    if (!final_used) {
         PTRACE(1, "H235\tCTS Error: expecting previous ciphertext");
         return 0;
     }
-    if (ctx->buf_len == 0) {
+    if (buf_len == 0) {
         PTRACE(1, "H235\tCTS Error: expecting previous plaintext");
         return 0;
     }
 
     /* handle leftover bytes */
-    leftover = ctx->buf_len;
+    leftover = buf_len;
 
     switch (EVP_CIPHER_CTX_mode(ctx)) {
         case EVP_CIPH_ECB_MODE: {
             /* encrypt => C_{n} plus C' */
-            if (!(ctx->cipher->do_cipher(ctx, tmp, ctx->final, bl))) {
+            if (!(EVP_Cipher(ctx, tmp, final_buf, bl))) {
                  return 0;
             }
 
             /* P_n plus C' */
-            memcpy(&(ctx->buf[leftover]), &(tmp[leftover]), (bl - leftover));
+            memcpy(&(buf[leftover]), &(tmp[leftover]), (bl - leftover));
             /* encrypt => C_{n-1} */
-            if (!(ctx->cipher->do_cipher(ctx, out, ctx->buf, bl))) {
+            if (!(EVP_Cipher(ctx, out, buf, bl))) {
                 return 0;
             }
 
@@ -177,18 +202,18 @@ int EVP_EncryptFinal_cts(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
         }
         case EVP_CIPH_CBC_MODE: {
             /* encrypt => C_{n} plus C' */
-            if (!(ctx->cipher->do_cipher(ctx, tmp, ctx->final, bl))) {
+            if (!(EVP_Cipher(ctx, tmp, final_buf, bl))) {
                 return 0;
             }
 
             /* P_n plus 0s */
-            memset(&(ctx->buf[leftover]), 0, (bl - leftover));
+            memset(&(buf[leftover]), 0, (bl - leftover));
 
             /* note that in cbc encryption, plaintext will be xor'ed with the previous
              * ciphertext, which is what we want.
              */
             /* encrypt => C_{n-1} */
-            if (!(ctx->cipher->do_cipher(ctx, out, ctx->buf, bl))) {
+            if (!(EVP_Cipher(ctx, out, buf, bl))) {
                 return 0;
             }
 
@@ -196,48 +221,99 @@ int EVP_EncryptFinal_cts(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
             *outl += (bl + leftover);
             return 1;
         }
-        default:
+        default: {
             PTRACE(1, "H235\tCTS Error: unsupported mode");
             return 0;
+        }
     }
 }
 
-int EVP_DecryptUpdate_cts(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
+int H235CryptoHelper::EncryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
                       const unsigned char *in, int inl)
 {
-    return EVP_EncryptUpdate_cts(ctx, out, outl, in, inl);
+    *outl = 0;
+
+    if (inl <= 0)
+        return inl == 0;
+
+    const int bl = EVP_CIPHER_CTX_block_size(ctx);
+    OPENSSL_assert(bl <= (int)sizeof(buf));
+    if (buf_len == 0 && (inl & (bl - 1)) == 0) {
+        if (!(EVP_Cipher(ctx, out, in, inl)))
+            return 0;
+
+        *outl = inl;
+        return 1;
+    }
+
+    int i = buf_len;
+    if (i != 0) {
+        if (i + inl < bl) {
+            memcpy(buf + i, in, inl);
+            buf_len += inl;
+            return 1;
+        } else {
+            int j = bl - i;
+            memcpy(buf + i, in, j);
+            if (!(EVP_Cipher(ctx, out, buf, bl)))
+                return 0;
+            inl -= j;
+            in += j;
+            out += bl;
+            *outl = bl;
+        }
+    }
+
+    i = inl & (bl - 1);
+    inl -= i;
+    if (inl > 0) {
+        if (!(EVP_Cipher(ctx, out, in, inl)))
+            return 0;
+        *outl += inl;
+    }
+
+    if (i != 0)
+        memcpy(buf, in + inl, i);
+    buf_len = i;
+    return 1;
 }
 
-int EVP_DecryptFinal_cts(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
+inline int H235CryptoHelper::DecryptUpdateCTS(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
+                      const unsigned char *in, int inl)
+{
+    return EncryptUpdateCTS(ctx, out, outl, in, inl);
+}
+
+int H235CryptoHelper::DecryptFinalCTS(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
 {
     unsigned char tmp[EVP_MAX_BLOCK_LENGTH];
-    int bl = ctx->cipher->block_size;
+    const int bl = EVP_CIPHER_CTX_block_size(ctx);
     int leftover = 0;
     *outl = 0;
 
-    if (!ctx->final_used) {
+    if (!final_used) {
         PTRACE(1, "H235\tCTS Error: expecting previous ciphertext");
         return 0;
     }
-    if (ctx->buf_len == 0) {
+    if (buf_len == 0) {
         PTRACE(1, "H235\tCTS Error: expecting previous ciphertext");
         return 0;
     }
 
     /* handle leftover bytes */
-    leftover = ctx->buf_len;
+    leftover = buf_len;
 
     switch (EVP_CIPHER_CTX_mode(ctx)) {
         case EVP_CIPH_ECB_MODE: {
             /* decrypt => P_n plus C' */
-            if (!(ctx->cipher->do_cipher(ctx, tmp, ctx->final, bl))) {
+            if (!(EVP_Cipher(ctx, tmp, final_buf, bl))) {
                 return 0;
             }
 
             /* C_n plus C' */
-            memcpy(&(ctx->buf[leftover]), &(tmp[leftover]), (bl - leftover));
+            memcpy(&(buf[leftover]), &(tmp[leftover]), (bl - leftover));
             /* decrypt => P_{n-1} */
-            if (!(ctx->cipher->do_cipher(ctx, out, ctx->buf, bl))) {
+            if (!(EVP_Cipher(ctx, out, buf, bl))) {
                 return 0;
             }
 
@@ -249,14 +325,14 @@ int EVP_DecryptFinal_cts(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
             int i = 0;
             unsigned char C_n_minus_2[EVP_MAX_BLOCK_LENGTH];
 
-            memcpy(C_n_minus_2, ctx->iv, bl);
+            memcpy(C_n_minus_2, EVP_CIPHER_CTX_iv(ctx), bl);
 
-            /* C_n plus 0s in ctx->buf */
-            memset(&(ctx->buf[leftover]), 0, (bl - leftover));
+            /* C_n plus 0s in buf */
+            memset(&(buf[leftover]), 0, (bl - leftover));
 
-            /* ctx->final is C_{n-1} */
+            /* final_buf is C_{n-1} */
             /* decrypt => (P_n plus C')'' */
-            if (!(ctx->cipher->do_cipher(ctx, tmp, ctx->final, bl))) {
+            if (!(EVP_Cipher(ctx, tmp, final_buf, bl))) {
                 return 0;
             }
             /* XOR'ed with C_{n-2} => (P_n plus C')' */
@@ -265,18 +341,18 @@ int EVP_DecryptFinal_cts(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
             }
             /* XOR'ed with (C_n plus 0s) => P_n plus C' */
             for (i = 0; i < bl; i++) {
-                tmp[i] = tmp[i] ^ ctx->buf[i];
+                tmp[i] = tmp[i] ^ buf[i];
             }
 
-            /* C_n plus C' in ctx->buf */
-            memcpy(&(ctx->buf[leftover]), &(tmp[leftover]), (bl - leftover));
+            /* C_n plus C' in buf */
+            memcpy(&(buf[leftover]), &(tmp[leftover]), (bl - leftover));
             /* decrypt => P_{n-1}'' */
-            if (!(ctx->cipher->do_cipher(ctx, out, ctx->buf, bl))) {
+            if (!(EVP_Cipher(ctx, out, buf, bl))) {
                 return 0;
             }
             /* XOR'ed with C_{n-1} => P_{n-1}' */
             for (i = 0; i < bl; i++) {
-                out[i] = out[i] ^ ctx->final[i];
+                out[i] = out[i] ^ final_buf[i];
             }
             /* XOR'ed with C_{n-2} => P_{n-1} */
             for (i = 0; i < bl; i++) {
@@ -287,64 +363,106 @@ int EVP_DecryptFinal_cts(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
             *outl += (bl + leftover);
             return 1;
         }
-        default:
+        default: {
             PTRACE(1, "H235\tCTS Error: unsupported mode");
             return 0;
+        }
     }
 }
 
-int EVP_DecryptFinal_relaxed(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
+int H235CryptoHelper::DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl,
+                      const unsigned char *in, int inl)
 {
-    unsigned int b = 0;
+    if (inl <= 0) {
+        *outl = 0;
+        return inl == 0;
+    }
+
+    if (EVP_CIPHER_CTX_test_flags(ctx, EVP_CIPH_NO_PADDING))
+        return EncryptUpdate(ctx, out, outl, in, inl);
+
+    const int bl = EVP_CIPHER_CTX_block_size(ctx);
+    OPENSSL_assert(bl <= (int)sizeof(final_buf));
+
+    int fix_len = 0;
+    if (final_used) {
+        memcpy(out, final_buf, bl);
+        out += bl;
+        fix_len = 1;
+    }
+
+    if (!EncryptUpdate(ctx, out, outl, in, inl))
+        return 0;
+
+    /*
+     * if we have 'decrypted' a multiple of block size, make sure we have a
+     * copy of this last block
+     */
+    if (bl > 1 && !buf_len) {
+        *outl -= bl;
+        final_used = 1;
+        memcpy(final_buf, out + *outl, bl);
+    }
+    else
+        final_used = 0;
+
+    if (fix_len)
+        *outl += bl;
+
+    return 1;
+}
+
+int H235CryptoHelper::DecryptFinalRelaxed(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl)
+{
     *outl = 0;
 
-    b=ctx->cipher->block_size;
-    if (ctx->flags & EVP_CIPH_NO_PADDING) {
-        if(ctx->buf_len) {
+    if (EVP_CIPHER_CTX_test_flags(ctx, EVP_CIPH_NO_PADDING)) {
+        if(buf_len) {
             PTRACE(1, "H235\tDecrypt error: data not a multiple of block length");
             return 0;
         }
-        *outl = 0;
         return 1;
     }
-    if (b > 1) {
-        if (ctx->buf_len || !ctx->final_used) {
+
+    const int bl = EVP_CIPHER_CTX_block_size(ctx);
+    if (bl > 1) {
+        if (buf_len || !final_used) {
             PTRACE(1, "H235\tDecrypt error: wrong final block length");
-            return(0);
+            return 0;
         }
-        OPENSSL_assert(b <= sizeof ctx->final);
-        int n=ctx->final[b-1];
-        if (n == 0 || n > (int)b) {
+        OPENSSL_assert(bl <= (int)sizeof(final_buf));
+        int n = final_buf[bl - 1];
+        if (n == 0 || n > bl) {
             PTRACE(1, "H235\tDecrypt error: bad decrypt");
-            return(0);
+            return 0;
         }
         // Polycom endpoints (eg. m100 and PVX) don't fill the padding propperly, so we have to disable this check
 /*
         for (int i=0; i<n; i++) {
-            if (ctx->final[--b] != n) {
+            if (final_buf[bl - i] != n) {
                 PTRACE(1, "H235\tDecrypt error: incorrect padding");
-                return(0);
+                return 0;
             }
         }
 */
-        n=ctx->cipher->block_size-n;
-        for (int i=0; i<n; i++)
-            out[i]=ctx->final[i];
-        *outl=n;
+        n = bl - n;
+        memcpy(out, final_buf, n);
+        *outl = n;
     }
-    else
-        *outl=0;
-    return(1);
+
+    return 1;
 }
 
 H235CryptoEngine::H235CryptoEngine(const PString & algorithmOID)
-:  m_algorithmOID(algorithmOID), m_operationCnt(0), m_initialised(false),
+:  m_encryptCtx(NULL), m_decryptCtx(NULL),
+   m_algorithmOID(algorithmOID), m_operationCnt(0), m_initialised(false),
    m_enc_blockSize(0), m_enc_ivLength(0), m_dec_blockSize(0), m_dec_ivLength(0)
 {
 }
 
 H235CryptoEngine::H235CryptoEngine(const PString & algorithmOID, const PBYTEArray & key)
-:  m_algorithmOID(algorithmOID), m_operationCnt(0), m_initialised(false),
+:  m_encryptCtx(NULL), m_decryptCtx(NULL),
+   m_algorithmOID(algorithmOID), m_operationCnt(0), m_initialised(false),
    m_enc_blockSize(0), m_enc_ivLength(0), m_dec_blockSize(0), m_dec_ivLength(0)
 {
     SetKey(key);
@@ -352,10 +470,10 @@ H235CryptoEngine::H235CryptoEngine(const PString & algorithmOID, const PBYTEArra
 
 H235CryptoEngine::~H235CryptoEngine()
 {
-    if (m_initialised) {
-        EVP_CIPHER_CTX_cleanup(&m_encryptCtx);
-        EVP_CIPHER_CTX_cleanup(&m_decryptCtx);
-    }
+    if (m_encryptCtx != NULL)
+      EVP_CIPHER_CTX_free(m_encryptCtx);
+    if (m_decryptCtx != NULL)
+      EVP_CIPHER_CTX_free(m_decryptCtx);
 }
 
 void H235CryptoEngine::SetKey(PBYTEArray key)
@@ -375,15 +493,47 @@ void H235CryptoEngine::SetKey(PBYTEArray key)
         return;
     }
 
-    EVP_CIPHER_CTX_init(&m_encryptCtx);
-    EVP_EncryptInit_ex(&m_encryptCtx, cipher, NULL, key.GetPointer(), NULL);
-    m_enc_blockSize =  EVP_CIPHER_CTX_block_size(&m_encryptCtx);
-    m_enc_ivLength = EVP_CIPHER_CTX_iv_length(&m_encryptCtx);
+    m_initialised = false;
 
-    EVP_CIPHER_CTX_init(&m_decryptCtx);
-    EVP_DecryptInit_ex(&m_decryptCtx, cipher, NULL, key.GetPointer(), NULL);
-    m_dec_blockSize =  EVP_CIPHER_CTX_block_size(&m_decryptCtx);
-    m_dec_ivLength = EVP_CIPHER_CTX_iv_length(&m_decryptCtx);
+    if (m_encryptCtx == NULL) {
+      m_encryptCtx = EVP_CIPHER_CTX_new();
+      if (m_encryptCtx == NULL) {
+        PTRACE(1, "H235\tFailed to allocate EVP encrypt context");
+        return;
+      }
+    } else {
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
+      EVP_CIPHER_CTX_cleanup(m_encryptCtx);
+      EVP_CIPHER_CTX_init(m_encryptCtx);
+#else
+      EVP_CIPHER_CTX_reset(m_encryptCtx);
+#endif
+    }
+
+    EVP_EncryptInit_ex(m_encryptCtx, cipher, NULL, key.GetPointer(), NULL);
+    m_enc_blockSize = EVP_CIPHER_CTX_block_size(m_encryptCtx);
+    m_enc_ivLength = EVP_CIPHER_CTX_iv_length(m_encryptCtx);
+    m_encryptHelper.Reset();
+
+    if (m_decryptCtx == NULL) {
+      m_decryptCtx = EVP_CIPHER_CTX_new();
+      if (m_decryptCtx == NULL) {
+        PTRACE(1, "H235\tFailed to allocate EVP decrypt context");
+        return;
+      }
+    } else {
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
+      EVP_CIPHER_CTX_cleanup(m_decryptCtx);
+      EVP_CIPHER_CTX_init(m_decryptCtx);
+#else
+      EVP_CIPHER_CTX_reset(m_decryptCtx);
+#endif
+    }
+
+    EVP_DecryptInit_ex(m_decryptCtx, cipher, NULL, key.GetPointer(), NULL);
+    m_dec_blockSize = EVP_CIPHER_CTX_block_size(m_decryptCtx);
+    m_dec_ivLength = EVP_CIPHER_CTX_iv_length(m_decryptCtx);
+    m_decryptHelper.Reset();
 
     m_operationCnt = 0;
     m_initialised = true;
@@ -414,40 +564,37 @@ PBYTEArray H235CryptoEngine::Encrypt(const PBYTEArray & _data, unsigned char * i
     unsigned char iv[EVP_MAX_IV_LENGTH];
 
     // max ciphertext len for a n bytes of plaintext is n + BLOCK_SIZE -1 bytes
-    int ciphertext_len = data.GetSize() + EVP_CIPHER_CTX_block_size(&m_encryptCtx);
+    int ciphertext_len = data.GetSize() + m_enc_blockSize;
     int final_len = 0;
     PBYTEArray ciphertext(ciphertext_len);
 
-    SetIV(iv, ivSequence, EVP_CIPHER_CTX_iv_length(&m_encryptCtx));
-    EVP_EncryptInit_ex(&m_encryptCtx, NULL, NULL, NULL, iv);
+    SetIV(iv, ivSequence, m_enc_ivLength);
+    EVP_EncryptInit_ex(m_encryptCtx, NULL, NULL, NULL, iv);
+    m_encryptHelper.Reset();
 
     // always use padding, because our ciphertext stealing implementation
     // doesn't seem to produce compatible results
-    //rtpPadding = (data.GetSize() < EVP_CIPHER_CTX_block_size(&m_encryptCtx));  // not interoperable!
-    rtpPadding = (data.GetSize() % EVP_CIPHER_CTX_block_size(&m_encryptCtx) > 0);
-    EVP_CIPHER_CTX_set_padding(&m_encryptCtx, rtpPadding ? 1 : 0);
+    //rtpPadding = (data.GetSize() < m_enc_blockSize);  // not interoperable!
+    rtpPadding = (data.GetSize() % m_enc_blockSize > 0);
+    EVP_CIPHER_CTX_set_padding(m_encryptCtx, rtpPadding ? 1 : 0);
 
-    if (!rtpPadding && (data.GetSize() % EVP_CIPHER_CTX_block_size(&m_encryptCtx) > 0)) {
+    if (!rtpPadding && (data.GetSize() % m_enc_blockSize > 0)) {
         // use cyphertext stealing
-        if (!EVP_EncryptUpdate_cts(&m_encryptCtx, ciphertext.GetPointer(), &ciphertext_len, data.GetPointer(), data.GetSize())) {
-            PTRACE(1, "H235\tEVP_EncryptUpdate_cts() failed");
+        if (!m_encryptHelper.EncryptUpdateCTS(m_encryptCtx, ciphertext.GetPointer(), &ciphertext_len, data.GetPointer(), data.GetSize())) {
+            PTRACE(1, "H235\tEncryptUpdateCTS() failed");
         }
-#if PTLIB_VER >= 2130
-        if (!EVP_EncryptFinal_ctsA(&m_encryptCtx, ciphertext.GetPointer() + ciphertext_len, &final_len)) {
-#else
-        if (!EVP_EncryptFinal_cts(&m_encryptCtx, ciphertext.GetPointer() + ciphertext_len, &final_len)) {
-#endif
-            PTRACE(1, "H235\tEVP_EncryptFinal_cts() failed");
+        if (!m_encryptHelper.EncryptFinalCTS(m_encryptCtx, ciphertext.GetPointer() + ciphertext_len, &final_len)) {
+            PTRACE(1, "H235\tEncryptFinalCTS() failed");
         }
     } else {
         /* update ciphertext, ciphertext_len is filled with the length of ciphertext generated,
          *len is the size of plaintext in bytes */
-        if (!EVP_EncryptUpdate(&m_encryptCtx, ciphertext.GetPointer(), &ciphertext_len, data.GetPointer(), data.GetSize())) {
+        if (!EVP_EncryptUpdate(m_encryptCtx, ciphertext.GetPointer(), &ciphertext_len, data.GetPointer(), data.GetSize())) {
             PTRACE(1, "H235\tEVP_EncryptUpdate() failed");
         }
 
         // update ciphertext with the final remaining bytes, if any use RTP padding
-        if (!EVP_EncryptFinal_ex(&m_encryptCtx, ciphertext.GetPointer() + ciphertext_len, &final_len)) {
+        if (!EVP_EncryptFinal_ex(m_encryptCtx, ciphertext.GetPointer() + ciphertext_len, &final_len)) {
             PTRACE(1, "H235\tEVP_EncryptFinal_ex() failed");
         }
     }
@@ -470,32 +617,29 @@ PINDEX H235CryptoEngine::EncryptInPlace(const BYTE * inData, PINDEX inLength, BY
     int inSize =  inLength + m_enc_blockSize;
 
     SetIV(m_iv, ivSequence, m_enc_ivLength);
-    EVP_EncryptInit_ex(&m_encryptCtx, NULL, NULL, NULL, m_iv);
+    EVP_EncryptInit_ex(m_encryptCtx, NULL, NULL, NULL, m_iv);
+    m_encryptHelper.Reset();
 
     rtpPadding = (inLength % m_enc_blockSize > 0);
-    EVP_CIPHER_CTX_set_padding(&m_encryptCtx, rtpPadding ? 1 : 0);
+    EVP_CIPHER_CTX_set_padding(m_encryptCtx, rtpPadding ? 1 : 0);
 
     if (!rtpPadding && (inLength % m_enc_blockSize > 0)) {
         // use cyphertext stealing
-        if (!EVP_EncryptUpdate_cts(&m_encryptCtx, outData, &inSize, inData, inLength)) {
+        if (!m_encryptHelper.EncryptUpdateCTS(m_encryptCtx, outData, &inSize, inData, inLength)) {
             PTRACE(1, "H235\tEVP_EncryptUpdate_cts() failed");
         }
-#if PTLIB_VER >= 2130
-        if (!EVP_EncryptFinal_ctsA(&m_encryptCtx, outData + inSize, &outSize)) {
-#else
-        if (!EVP_EncryptFinal_cts(&m_encryptCtx, outData + inSize, &outSize)) {
-#endif
+        if (!m_encryptHelper.EncryptFinalCTS(m_encryptCtx, outData + inSize, &outSize)) {
             PTRACE(1, "H235\tEVP_EncryptFinal_cts() failed");
         }
     } else {
         /* update ciphertext, ciphertext_len is filled with the length of ciphertext generated,
          *len is the size of plaintext in bytes */
-        if (!EVP_EncryptUpdate(&m_encryptCtx, outData, &inSize, inData, inLength)) {
+        if (!EVP_EncryptUpdate(m_encryptCtx, outData, &inSize, inData, inLength)) {
             PTRACE(1, "H235\tEVP_EncryptUpdate() failed");
         }
 
         // update ciphertext with the final remaining bytes, if any use RTP padding
-        if (!EVP_EncryptFinal_ex(&m_encryptCtx, outData + inSize, &outSize)) {
+        if (!EVP_EncryptFinal_ex(m_encryptCtx, outData + inSize, &outSize)) {
             PTRACE(1, "H235\tEVP_EncryptFinal_ex() failed");
         }
     }
@@ -515,25 +659,26 @@ PBYTEArray H235CryptoEngine::Decrypt(const PBYTEArray & _data, unsigned char * i
     int final_len = 0;
     PBYTEArray plaintext(plaintext_len);
 
-    SetIV(iv, ivSequence, EVP_CIPHER_CTX_iv_length(&m_decryptCtx));
-    EVP_DecryptInit_ex(&m_decryptCtx, NULL, NULL, NULL, iv);
+    SetIV(iv, ivSequence, m_dec_ivLength);
+    EVP_DecryptInit_ex(m_decryptCtx, NULL, NULL, NULL, iv);
+    m_decryptHelper.Reset();
 
-    EVP_CIPHER_CTX_set_padding(&m_decryptCtx, rtpPadding ? 1 : 0);
+    EVP_CIPHER_CTX_set_padding(m_decryptCtx, rtpPadding ? 1 : 0);
 
-    if (!rtpPadding && data.GetSize() % EVP_CIPHER_CTX_block_size(&m_decryptCtx) > 0) {
+    if (!rtpPadding && data.GetSize() % m_dec_blockSize > 0) {
         // use cyphertext stealing
-        if (!EVP_DecryptUpdate_cts(&m_decryptCtx, plaintext.GetPointer(), &plaintext_len, data.GetPointer(), data.GetSize())) {
-            PTRACE(1, "H235\tEVP_DecryptUpdate_cts() failed");
+        if (!m_decryptHelper.DecryptUpdateCTS(m_decryptCtx, plaintext.GetPointer(), &plaintext_len, data.GetPointer(), data.GetSize())) {
+            PTRACE(1, "H235\tDecryptUpdateCTS() failed");
         }
-        if(!EVP_DecryptFinal_cts(&m_decryptCtx, plaintext.GetPointer() + plaintext_len, &final_len)) {
-            PTRACE(1, "H235\tEVP_DecryptFinal_cts() failed");
+        if(!m_decryptHelper.DecryptFinalCTS(m_decryptCtx, plaintext.GetPointer() + plaintext_len, &final_len)) {
+            PTRACE(1, "H235\tDecryptFinalCTS() failed");
         }
     } else {
-        if (!EVP_DecryptUpdate(&m_decryptCtx, plaintext.GetPointer(), &plaintext_len, data.GetPointer(), data.GetSize())) {
-            PTRACE(1, "H235\tEVP_DecryptUpdate() failed");
+        if (!m_decryptHelper.DecryptUpdate(m_decryptCtx, plaintext.GetPointer(), &plaintext_len, data.GetPointer(), data.GetSize())) {
+            PTRACE(1, "H235\tDecryptUpdate() failed");
         }
-        if (!EVP_DecryptFinal_relaxed(&m_decryptCtx, plaintext.GetPointer() + plaintext_len, &final_len)) {
-            PTRACE(1, "H235\tEVP_DecryptFinal_ex() failed - incorrect padding ?");
+        if (!m_decryptHelper.DecryptFinalRelaxed(m_decryptCtx, plaintext.GetPointer() + plaintext_len, &final_len)) {
+            PTRACE(1, "H235\tDecryptFinalRelaxed() failed - incorrect padding ?");
         }
     }
 
@@ -551,27 +696,28 @@ PINDEX H235CryptoEngine::DecryptInPlace(const BYTE * inData, PINDEX inLength, BY
     int inSize =  inLength;
 
     SetIV(m_iv, ivSequence, m_dec_ivLength);
-    EVP_DecryptInit_ex(&m_decryptCtx, NULL, NULL, NULL, m_iv);
+    EVP_DecryptInit_ex(m_decryptCtx, NULL, NULL, NULL, m_iv);
+    m_decryptHelper.Reset();
 
-    EVP_CIPHER_CTX_set_padding(&m_decryptCtx, rtpPadding ? 1 : 0);
+    EVP_CIPHER_CTX_set_padding(m_decryptCtx, rtpPadding ? 1 : 0);
 
     if (!rtpPadding && inLength % m_dec_blockSize > 0) {
         // use cyphertext stealing
-        if (!EVP_DecryptUpdate_cts(&m_decryptCtx, outData, &inSize, inData, inLength)) {
-            PTRACE(1, "H235\tEVP_DecryptUpdate_cts() failed");
+        if (!m_decryptHelper.DecryptUpdateCTS(m_decryptCtx, outData, &inSize, inData, inLength)) {
+            PTRACE(1, "H235\tDecryptUpdateCTS() failed");
 			return 0;	// no usable payload
         }
-        if(!EVP_DecryptFinal_cts(&m_decryptCtx, outData + inSize, &outSize)) {
-            PTRACE(1, "H235\tEVP_DecryptFinal_cts() failed");
+        if(!m_decryptHelper.DecryptFinalCTS(m_decryptCtx, outData + inSize, &outSize)) {
+            PTRACE(1, "H235\tDecryptFinalCTS() failed");
 			return 0;	// no usable payload
         }
     } else {
-        if (!EVP_DecryptUpdate(&m_decryptCtx, outData, &inSize, inData, inLength)) {
-            PTRACE(1, "H235\tEVP_DecryptUpdate() failed");
+        if (!m_decryptHelper.DecryptUpdate(m_decryptCtx, outData, &inSize, inData, inLength)) {
+            PTRACE(1, "H235\tDecryptUpdate() failed");
 			return 0;	// no usable payload
         }
-        if (!EVP_DecryptFinal_relaxed(&m_decryptCtx, outData + inSize, &outSize)) {
-            PTRACE(1, "H235\tEVP_DecryptFinal_ex() failed - incorrect padding ?");
+        if (!m_decryptHelper.DecryptFinalRelaxed(m_decryptCtx, outData + inSize, &outSize)) {
+            PTRACE(1, "H235\tDecryptFinalRelaxed() failed - incorrect padding ?");
 			return 0;	// no usable payload
         }
     }


### PR DESCRIPTION
This commit adds compatibility with OpenSSL 1.1.0 to h235 implementation. The CTS crypto functions were reworked as a helper class which stores the necessary cipher members that are not available publicly in OpenSSL 1.1.0 locally.

Unlike 9a65ea28ba50ce6fe8239fa7e2c69c5086be7aba, this commit also adds a proper non-CTS DecryptUpdate implementation, which is needed to keep the internal buffer in the helper updated until it is used in DecryptFinalRelaxed. This implementation which also includes EncryptUpdate, is based on the code from OpenSSL.

Only tested with a local unit test for encryption/decryption roundtrip and also that the encrypted data is the same as the encrypted data before the patch.
