### PR TITLE
Fixed #if directives

### DIFF
--- a/include/codecs.h
+++ b/include/codecs.h
@@ -724,7 +724,7 @@ class H323StreamedAudioCodec : public H323FramedAudioCodec
     unsigned bitsPerSample;
 };
 
-#endif // NO_H323_AUDIO_CODECS
+#endif // H323_AUDIO_CODECS
 
 
 #ifdef H323_VIDEO
@@ -997,7 +997,7 @@ class H323VideoCodec : public H323Codec
     PMutex  videoHandlerActive;
 };
 
-#endif // NO_H323_VIDEO
+#endif // H323_VIDEO
 
 #ifdef H323_AUDIO_CODECS
 
@@ -1061,7 +1061,7 @@ class H323_muLawCodec : public H323StreamedAudioCodec
     PBoolean sevenBit;
 };
 
-#endif // NO_H323_AUDIO_CODECS
+#endif // H323_AUDIO_CODECS
 
 
 #endif // __CODECS_H

--- a/include/h323caps.h
+++ b/include/h323caps.h
@@ -636,7 +636,7 @@ class H323RealTimeCapability : public H323Capability
   //@}
 };
 
-#ifndef NO_H323_AUDIO
+#ifdef H323_AUDIO_CODECS
 
 /**This class describes the interface to an audio codec used to transfer data
    via the logical channels opened and managed by the H323 control channel.
@@ -1812,7 +1812,7 @@ class H323_G711Capability : public H323AudioCapability
     Speed    speed;
 };
 
-#endif // NO_H323_AUDIO_CODECS
+#endif // H323_AUDIO_CODECS
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/include/h323con.h
+++ b/include/h323con.h
@@ -3334,7 +3334,7 @@ class H323Connection : public PObject
 
 #endif
 
-#ifdef H323_FRAMEBUFFER
+#if defined(H323_VIDEO) && defined(H323_FRAMEBUFFER)
     void EnableVideoFrameBuffer(PBoolean enable);
     PBoolean HasVideoFrameBuffer();
 #endif

--- a/include/h323ep.h
+++ b/include/h323ep.h
@@ -2565,7 +2565,7 @@ class H323EndPoint : public PObject
     void SetTLSMediaPolicy(H323TransportSecurity::Policy policy);
     H323TransportSecurity * GetTransportSecurity();
 
-#ifdef H323_FRAMEBUFFER
+#if defined(H323_VIDEO) && defined(H323_FRAMEBUFFER)
     void EnableVideoFrameBuffer(PBoolean enable);
     PBoolean HasVideoFrameBuffer();
 #endif
@@ -3208,7 +3208,7 @@ class H323EndPoint : public PObject
     GNUGK_Feature * gnugk;
 #endif
 
-#ifdef H323_FRAMEBUFFER
+#if defined(H323_VIDEO) && defined(H323_FRAMEBUFFER)
     PBoolean useVideoBuffer;
 #endif
 

--- a/include/opalvxml.h
+++ b/include/opalvxml.h
@@ -43,6 +43,9 @@
 
 //////////////////////////////////////////////////////////////////
 
+
+#ifdef H323_AUDIO_CODECS
+
 class G7231_File_Codec : public H323AudioCodec
 {
   PCLASSINFO(G7231_File_Codec, H323AudioCodec);
@@ -82,6 +85,7 @@ class G7231_File_Capability : public H323AudioCapability
     PObject * Clone() const;
 };
 
+#endif
 
 //////////////////////////////////////////////////////////////////
 

--- a/include/ptlib_extras.h
+++ b/include/ptlib_extras.h
@@ -745,7 +745,7 @@ template <class D> class PSTLList : public PObject,
       { return PNEW cls(0, this); } \
 
 
-#ifdef H323_FRAMEBUFFER
+#if (defined(H323_VIDEO) || defined(H323_AUDIO_CODECS)) && defined(H323_FRAMEBUFFER)
 
 class H323FRAME {
 public:

--- a/src/codecs.cxx
+++ b/src/codecs.cxx
@@ -1258,4 +1258,4 @@ short H323_muLawCodec::DecodeSample(int sample)
 
 /////////////////////////////////////////////////////////////////////////////
 
-#endif // NO_H323_AUDIO_CODECS
+#endif // H323_AUDIO_CODECS

--- a/src/h323.cxx
+++ b/src/h323.cxx
@@ -7733,7 +7733,7 @@ PBoolean H323Connection::OpenConferenceControlSession(PBoolean & chairControl, P
 
 #endif  // H323_H230
 
-#ifdef H323_FRAMEBUFFER
+#if defined(H323_VIDEO) && defined(H323_FRAMEBUFFER)
 void H323Connection::EnableVideoFrameBuffer(PBoolean enable)
 {
     endpoint.EnableVideoFrameBuffer(enable);

--- a/src/h323ep.cxx
+++ b/src/h323ep.cxx
@@ -934,7 +934,7 @@ H323EndPoint::H323EndPoint()
   m_transportContext = NULL;
 #endif
 
-#ifdef H323_FRAMEBUFFER
+#if defined(H323_VIDEO) && defined(H323_FRAMEBUFFER)
   useVideoBuffer = false;
 #endif
 
@@ -4144,7 +4144,7 @@ bool H323EndPoint::H46025GPSInformation(H323_H46025_Message::Geodetic & /*gps*/)
 }
 #endif  // H323_H46025
 
-#ifdef H323_FRAMEBUFFER
+#if defined(H323_AUDIO_CODECS) && defined(H323_FRAMEBUFFER)
 void H323EndPoint::EnableVideoFrameBuffer(PBoolean enable)
 {
     if (useVideoBuffer == enable)

--- a/src/h323pluginmgr.cxx
+++ b/src/h323pluginmgr.cxx
@@ -392,7 +392,7 @@ int OpalG711uLaw64k20_Decoder::Encode(const void * _from, unsigned * fromLen, vo
 }
 
 
-#endif // NO_H323_AUDIO_CODECS
+#endif // H323_AUDIO_CODECS
 
 //////////////////////////////////////////////////////////////////////////////
 //
@@ -484,6 +484,7 @@ bool OpalPluginCodec::SetCustomFormat(unsigned bitrate, unsigned samplerate)
     return SetCustomisedOptions(codecDefn, context, bitrate, samplerate);
 }
 
+#if defined(H323_AUDIO_CODECS) || defined(H323_VIDEO)
 static PBoolean SetCodecControl(const PluginCodec_Definition * codec,
                                                     void * context,
                                               const char * name,
@@ -505,7 +506,6 @@ static PBoolean SetCodecControl(const PluginCodec_Definition * codec,
   return result;
 }
 
-#if defined(H323_AUDIO_CODECS) || defined(H323_VIDEO)
 static PBoolean SetCodecControl(const PluginCodec_Definition * codec,
                                                     void * context,
                                               const char * name,
@@ -918,7 +918,7 @@ static H323Capability * CreateGSMCap(
   int subType
 );
 
-#endif // NO_H323_AUDIO
+#endif // H323_AUDIO_CODECS
 
 /////////////////////////////////////////////////////
 
@@ -1254,7 +1254,7 @@ class H323StreamedPluginAudioCodec : public H323StreamedAudioCodec
     PluginCodec_Definition * codec;
 };
 
-#endif //  NO_H323_AUDIO_CODECS
+#endif // H323_AUDIO_CODECS
 
 //////////////////////////////////////////////////////////////////////////////
 //
@@ -1277,7 +1277,7 @@ static void CheckPacket(PBoolean encode, const RTP_DataFrame & frame)
 }
 #endif
 
-#ifdef H323_FRAMEBUFFER
+#if (defined(H323_VIDEO) || defined(H323_AUDIO_CODECS)) && defined(H323_FRAMEBUFFER)
 
 class H323PluginFrameBuffer : public H323_FrameBuffer
 {
@@ -2142,7 +2142,7 @@ class H323PluginCapabilityInfo
     PString                  mediaFormatName;
 };
 
-#ifndef NO_H323_AUDIO
+#ifdef H323_AUDIO_CODECS
 
 //////////////////////////////////////////////////////////////////////////////
 //
@@ -2180,7 +2180,7 @@ class H323AudioPluginCapability : public H323AudioCapability,
             break;
           }
         }
-#endif
+#endif // H323_AUDIO_CODECS
         rtpPayloadType = OpalMediaFormat(_mediaFormat).GetPayloadType();
       }
 
@@ -2362,9 +2362,9 @@ class H323GSMPluginCapability : public H323AudioPluginCapability
     int scrambled;
 };
 
-#endif // NO_H323_AUDIO_CODECS
+#endif // H323_AUDIO_CODECS
 
-#endif // NO_H323_AUDIO
+#endif // H323_AUDIO_CODECS
 
 #ifdef  H323_VIDEO
 
@@ -2900,7 +2900,7 @@ void H323PluginCodecManager::CreateCapabilityAndMediaFormat(
       jitter = FALSE;
       break;
 #endif
-#ifndef NO_H323_AUDIO
+#ifdef H323_AUDIO_CODECS
     case PluginCodec_MediaTypeAudio:
     case PluginCodec_MediaTypeAudioStreamed:
       defaultSessionID = OpalMediaFormat::DefaultAudioSessionID;
@@ -2942,7 +2942,7 @@ void H323PluginCodecManager::CreateCapabilityAndMediaFormat(
                                   timeStamp);
           break;
 #endif
-#ifndef NO_H323_AUDIO
+#ifdef H323_AUDIO_CODECS
         case PluginCodec_MediaTypeAudio:
         case PluginCodec_MediaTypeAudioStreamed:
           mediaFormat = new OpalPluginAudioMediaFormat(
@@ -2965,7 +2965,7 @@ void H323PluginCodecManager::CreateCapabilityAndMediaFormat(
         OpalMediaFormat::List & list = H323PluginCodecManager::GetMediaFormatList();
         for (PINDEX i = 0; i < list.GetSize(); i++) {
           OpalMediaFormat * opalFmt = &list[i];
-#ifndef NO_H323_AUDIO
+#ifdef H323_AUDIO_CODECS
          {
           OpalPluginAudioMediaFormat * fmt = dynamic_cast<OpalPluginAudioMediaFormat *>(opalFmt);
           if (
@@ -3033,12 +3033,12 @@ void H323PluginCodecManager::CreateCapabilityAndMediaFormat(
           cap = (*map[i].createFunc)(encoderCodec, decoderCodec, map[i].h323SubType);
         else {
           switch (encoderCodec->flags & PluginCodec_MediaTypeMask) {
-#ifndef NO_H323_AUDIO
+#ifdef H323_AUDIO_CODECS
             case PluginCodec_MediaTypeAudio:
             case PluginCodec_MediaTypeAudioStreamed:
               cap = new H323AudioPluginCapability(encoderCodec, decoderCodec, map[i].h323SubType);
               break;
-#endif // NO_H323_AUDIO
+#endif // H323_AUDIO_CODECS
 
 #ifdef H323_VIDEO
             case PluginCodec_MediaTypeVideo:
@@ -3211,7 +3211,7 @@ H323Codec * H323PluginCapabilityInfo::CreateCodec(const OpalMediaFormat & mediaF
 #ifdef H323_AUDIO_CODECS
       PTRACE(3, "H323PLUGIN\tCreating framed audio codec " << mediaFormatName << " from plugin");
       return new H323PluginFramedAudioCodec(mediaFormat, direction, codec);
-#endif  // NO_H323_AUDIO_CODECS
+#endif  // H323_AUDIO_CODECS
 
     case PluginCodec_MediaTypeAudioStreamed:
 #ifndef H323_AUDIO_CODECS

--- a/src/opalvxml.cxx
+++ b/src/opalvxml.cxx
@@ -54,6 +54,9 @@
 
 ///////////////////////////////////////////////////////////////
 
+
+#ifdef H323_AUDIO_CODECS
+
 G7231_File_Capability::G7231_File_Capability()
   : H323AudioCapability(8, 4)
 {
@@ -198,6 +201,8 @@ unsigned G7231_File_Codec::GetAverageSignalLevel()
   else
     return UINT_MAX;
 }
+
+#endif
 
 ///////////////////////////////////////////////////////////////
 

--- a/src/transports.cxx
+++ b/src/transports.cxx
@@ -1398,7 +1398,7 @@ void H323ListenerTCP::Main()
     if (transport != NULL)
       new H225TransportThread(endpoint, transport);
   }
-#ifdef P_SSL
+#ifdef H323_TLS
 #if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
   ERR_remove_thread_state(NULL);
 #endif


### PR DESCRIPTION
I wanted to use `h323plus` just to parse h323 binary packets. So audio and video codecs are not required. 
```bash
./configure --disable-h46018 --disable-h46023 --disable-t38 --disable-h239 \
      --disable-audio --disable-video --disable-file --disable-tls
```
```bash
make -j bothdepend
```
```bash
make -j bothnoshared
```
However due to directive errors, last step could not be completed. So I've made the following changes and then make succeeded.

- Replaced `NO_H323_AUDIO_CODECS` with `H323_AUDIO_CODECS` since there is no definition of `NO_H323_AUDIO_CODECS` (maybe obsolete)
- check for also `H323_AUDIO_CODECS` and `H323_VIDEO` where `H323_FRAMEBUFFER` is checked
- Replaced `P_SSL` with `H323_TLS` since `P_SSL` is not configurable