### PR TITLE
Avoid out-of-bounds access

### DIFF
--- a/plugins/audio/G.722.2/AMR-WB/dec_if.c
+++ b/plugins/audio/G.722.2/AMR-WB/dec_if.c
@@ -182,6 +182,10 @@ Word16 D_IF_conversion(Word16 *param, UWord8 *stream, UWord8 *frame_type,
 
       /* speech mode indicator */
       *speech_mode = (Word16)(*stream >> 4);
+      if (*speech_mode < 0 || *speech_mode >= NUM_OF_SPMODES) {
+        *speech_mode = 0;
+        *frame_type = RX_SPEECH_LOST;
+      }
       break;
 
    case MRNO_DATA:
@@ -514,6 +518,10 @@ Word16 D_IF_mms_conversion(Word16 *param, UWord8 *stream, UWord8 *frame_type,
 
       /* speech mode indicator */
       *speech_mode = (Word16)(*stream >> 4);
+      if (*speech_mode < 0 || *speech_mode >= NUM_OF_SPMODES) {
+        *speech_mode = 0;
+        *frame_type = RX_SPEECH_LOST;
+      }
       break;
 
    case MRNO_DATA:


### PR DESCRIPTION
According to encoder logic speech_mode is in the range `0..8`. `D_IF_homing_frame_test_first` relies on that; i.e. if `speech_mode` is out of the mentioned range, then out-of-bounds access happens.

This PR adds a check that `speech_mode` is valid right after it is parsed; in case it is invalid, current frame is marked as invalid (`RX_SPEECH_LOST`); as a result usual logic for decoding recovery is applied.