### PR TITLE
Fix transport thread cleanup ordering

### DIFF
--- a/src/transports.cxx
+++ b/src/transports.cxx
@@ -1208,7 +1208,11 @@ void H323Transport::CleanUpOnTermination()
 
   if (thread != NULL) {
     PTRACE(3, "H323\tH323Transport::CleanUpOnTermination for " << thread->GetThreadName());
-    PAssert(thread->WaitForTermination(10000), "Transport thread did not terminate");
+    if (!thread->WaitForTermination(10000)) {
+      PTRACE(1, "H323\tTransport thread did not terminate in 10 seconds; forcing termination");
+      thread->Terminate();
+      thread->WaitForTermination();
+    }
     delete thread;
     thread = NULL;
   }

--- a/tests/transport_cleanup/Makefile
+++ b/tests/transport_cleanup/Makefile
@@ -1,0 +1,10 @@
+# Regression test for H323Transport::CleanUpOnTermination().
+
+PROG := transport_cleanup_test
+SOURCES := main.cxx
+
+ifndef OPENH323DIR
+OPENH323DIR := $(CURDIR)/../..
+endif
+
+include $(OPENH323DIR)/openh323u.mak

--- a/tests/transport_cleanup/README.md
+++ b/tests/transport_cleanup/README.md
@@ -1,0 +1,101 @@
+# Transport cleanup regression test
+
+This test covers a race in `H323Transport::CleanUpOnTermination()`. The old
+implementation waited ten seconds for the attached signalling thread and then
+deleted its `PThread` object regardless of whether `Main()` was still running.
+An outbound H.225 thread could subsequently access its freed thread object and
+`H323Connection`.
+
+The test deliberately runs an attached thread for 12.5 seconds without a
+cancellation point. Its destructor records a failure if the thread object is
+deleted before the operating-system thread has stopped. On POSIX, deferred
+cancellation lets the test thread return normally after about 12.5 seconds. On
+Windows, PTLib forcibly terminates it after the ten-second cleanup timeout.
+
+Start with sibling `ptlib` and `h323plus` source directories. The H323Plus
+checkout must contain this test and the corresponding transport fix; when
+testing a patch, apply it before building.
+
+## Ubuntu or Debian Linux VM
+
+Install the build dependencies in a fresh VM, then clone both repositories:
+
+```sh
+sudo apt-get update
+sudo apt-get install -y build-essential git pkg-config autoconf automake \
+  flex bison libssl-dev
+git clone https://github.com/willamowius/ptlib.git
+git clone https://github.com/willamowius/h323plus.git
+# Apply the patch to h323plus here, for example:
+# git -C h323plus am /path/to/0001-fix.patch
+```
+
+Configure static release builds and run the test:
+
+```sh
+cd ptlib
+./configure --disable-odbc --disable-sdl --disable-lua --disable-expat
+make -j"$(nproc)" optnoshared
+cd ../h323plus
+export PTLIBDIR="$(cd ../ptlib && pwd)"
+export OPENH323DIR="$PWD"
+./configure --disable-h235 --disable-h235-256
+make -j"$(nproc)" optnoshared
+make -C tests/transport_cleanup optnoshared
+TEST_BINARY="$(find tests/transport_cleanup -type f \
+  -name transport_cleanup_test -print -quit)"
+test -n "$TEST_BINARY"
+"$TEST_BINARY"
+```
+
+The current PTLib `master` branch matches H323Plus upstream CI. To reproduce
+the XMeeting dependency exactly on Linux, check out PTLib tag `v2_10_9_6`
+before configuring; the test supports both versions.
+
+A successful run takes about 13 seconds and prints:
+
+```text
+PASS: transport waited for thread termination before deletion
+```
+
+The test was verified on Ubuntu 24.04 x86-64 against both sides of the change.
+The unmodified parent revision reports H323Plus's `Transport thread did not
+terminate` assertion followed by:
+
+```text
+FAIL: transport deleted a thread whose Main() was running
+```
+
+and exits with status 1. With the transport cleanup fix applied, it prints the
+PASS result above and exits with status 0.
+
+## Windows 10 or 11 VM
+
+Install Visual Studio 2022 with **Desktop development with C++**, Git, and a
+Windows 10/11 SDK. In a **Developer Command Prompt for VS 2022**, clone current
+PTLib and H323Plus beside one another, then apply the patch being tested:
+
+```bat
+mkdir h323plus-cleanup-test
+cd h323plus-cleanup-test
+git clone https://github.com/willamowius/ptlib.git
+git clone https://github.com/willamowius/h323plus.git
+rem Apply the patch to h323plus here, for example:
+rem git -C h323plus am C:\path\to\0001-fix.patch
+cd h323plus
+msbuild h323plus_2022.sln /m /p:Configuration=Release /p:Platform=x64
+msbuild tests\transport_cleanup\transport_cleanup_2022.vcxproj /m /p:Configuration=Release /p:Platform=x64
+tests\transport_cleanup\Release_x64\transport_cleanup_test.exe
+```
+
+A successful run prints:
+
+```text
+PASS: transport waited for thread termination before deletion
+```
+
+Expect the Windows run to take about ten seconds. Use current PTLib for this
+clean-VM procedure: the older `v2_10_9_6` tag predates fixes to its Visual
+Studio 2022 configure-project bootstrap. Windows PTLib uses
+`TerminateThread()` for forced termination, while POSIX PTLib uses deferred
+`pthread_cancel()`; the test verifies safe deletion with both behaviors.

--- a/tests/transport_cleanup/main.cxx
+++ b/tests/transport_cleanup/main.cxx
@@ -1,0 +1,122 @@
+/*
+ * Regression test for transport thread cleanup.
+ *
+ * Copyright (c) 2026 XMeeting contributors
+ * Licensed under the Mozilla Public License Version 1.0.
+ */
+
+#include <ptlib.h>
+
+#include <h323ep.h>
+#include <transports.h>
+
+#include <atomic>
+#include <iostream>
+
+namespace {
+
+struct ThreadState {
+  std::atomic<bool> started;
+  std::atomic<bool> destroyed;
+  std::atomic<bool> destroyedWhileRunning;
+
+  ThreadState()
+    : started(false),
+      destroyed(false),
+      destroyedWhileRunning(false)
+  {
+  }
+};
+
+class DelayedTransportThread : public PThread
+{
+  PCLASSINFO(DelayedTransportThread, PThread);
+
+ public:
+  explicit DelayedTransportThread(ThreadState & state)
+    : PThread(65536, NoAutoDeleteThread, NormalPriority, "Cleanup regression"),
+      state(state)
+  {
+  }
+
+  ~DelayedTransportThread()
+  {
+    if (!IsTerminated())
+      state.destroyedWhileRunning.store(true);
+    state.destroyed.store(true);
+  }
+
+  void Main()
+  {
+    // Keep only the external state pointer in local storage. The old cleanup
+    // code deletes this PThread after ten seconds while Main() is still
+    // executing on POSIX. Avoiding further member access lets the destructor
+    // report that ordering error instead of relying only on a crash.
+    ThreadState * const result = &state;
+    result->started.store(true);
+
+    const PTimeInterval runFor(12500);
+    const PTimeInterval startedAt = PTimer::Tick();
+    while (PTimer::Tick() - startedAt < runFor) {
+      // Intentionally contain no cancellation point. CleanUpOnTermination()
+      // must not delete the PThread object until this Main() has returned.
+    }
+  }
+
+ private:
+  ThreadState & state;
+};
+
+class TransportCleanupTestProcess : public PProcess
+{
+  PCLASSINFO(TransportCleanupTestProcess, PProcess);
+
+ public:
+  TransportCleanupTestProcess()
+    : PProcess("H323Plus", "transport-cleanup-test", 1, 0, ReleaseCode, 0)
+  {
+  }
+
+  void Main()
+  {
+    H323EndPoint endpoint;
+    H323TransportTCP transport(endpoint);
+    ThreadState state;
+
+    DelayedTransportThread * const worker = new DelayedTransportThread(state);
+    transport.AttachThread(worker);
+    worker->Resume();
+
+    const PTimeInterval startupDeadline = PTimer::Tick() + PTimeInterval(5000);
+    while (!state.started.load() && PTimer::Tick() < startupDeadline)
+      PThread::Sleep(10);
+
+    if (!state.started.load()) {
+      std::cerr << "FAIL: worker thread did not start" << std::endl;
+      SetTerminationValue(1);
+      return;
+    }
+
+    transport.CleanUpOnTermination();
+
+    if (state.destroyedWhileRunning.load()) {
+      std::cerr << "FAIL: transport deleted a thread whose Main() was running"
+                << std::endl;
+      SetTerminationValue(1);
+      return;
+    }
+    if (!state.destroyed.load()) {
+      std::cerr << "FAIL: transport did not delete its terminated thread"
+                << std::endl;
+      SetTerminationValue(1);
+      return;
+    }
+
+    std::cout << "PASS: transport waited for thread termination before deletion"
+              << std::endl;
+  }
+};
+
+} // namespace
+
+PCREATE_PROCESS(TransportCleanupTestProcess);

--- a/tests/transport_cleanup/transport_cleanup_2022.vcxproj
+++ b/tests/transport_cleanup/transport_cleanup_2022.vcxproj
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{0AA7E29A-1ADC-4D0B-B631-5CB4680663F5}</ProjectGuid>
+    <ProjectName>transport_cleanup_test</ProjectName>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir>$(Configuration)_$(PlatformShortName)\</OutDir>
+    <IntDir>$(OutDir)obj\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;PTRACING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <WarningLevel>Level3</WarningLevel>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalIncludeDirectories>..\..\..\ptlib\include;..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link><SubSystem>Console</SubSystem></Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <PreprocessorDefinitions>NDEBUG;PTRACING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <WarningLevel>Level3</WarningLevel>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalIncludeDirectories>..\..\..\ptlib\include;..\..\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link><SubSystem>Console</SubSystem></Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="main.cxx" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\ptlib\src\ptlib\msos\Console_2022.vcxproj">
+      <Project>{D11E1C9D-406C-4D7C-8F37-913C0BFD9E0D}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\h323plus_2022.vcxproj">
+      <Project>{71C46EAF-48C9-47BA-9532-27B51744548D}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>


### PR DESCRIPTION
While working on my own project to modernize XMeeting for current macOS releases, ChatGPT and I traced a call-cleanup crash to `H323Transport::CleanUpOnTermination()`.

The existing implementation waits up to ten seconds for the attached transport thread, asserts if the wait expires, and then deletes the `PThread` object even if its `Main()` method is still running. This change explicitly terminates a thread that misses the deadline, waits until termination is complete, and only then deletes the object.

This pull request also adds a focused regression executable and build instructions for Linux and Windows. The test attaches a deliberately delayed transport thread and verifies that its object is not deleted while `Main()` is still active.

Verified results on Ubuntu 24.04 x86-64, using the same test harness and PTLib source for both runs:

- Unmodified parent revision: H323Plus reports `Transport thread did not terminate`; the regression test reports `FAIL: transport deleted a thread whose Main() was running` and exits 1.
- Patched revision: the test reports `PASS: transport waited for thread termination before deletion` and exits 0.

The patched test also passes on macOS. A Visual Studio 2022 x64 project and Windows VM instructions are included, although I have not yet executed that project in a Windows VM.

I would like to submit this fix upstream for review. I developed and tested it with assistance from ChatGPT, and I am happy to adjust the implementation or test layout to match the project's preferences.
